### PR TITLE
Configure building Rust project for Raspberry Pi

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -74,6 +74,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      
+      - name: Add target
+        run: rustup target add armv7-unknown-linux-gnueabihf
+      
+      - name: Install target building dependencies
+        run: sudo apt-get -qq install crossbuild-essential-armhf
 
       - name: Run cargo test
         run: cargo test
@@ -84,5 +90,8 @@ jobs:
       - name: Lint pod operation
         run: cargo clippy -- -D warnings
 
-      - name: Build Pod Operation Program
-        run: cargo build
+      - name: Build Pod Operation Program (debug)
+        run: cargo build --config target.armv7-unknown-linux-gnueabihf.linker=\"arm-linux-gnueabihf-gcc\"
+
+      - name: Build Pod Operation Program (release)
+        run: cargo build --config target.armv7-unknown-linux-gnueabihf.linker=\"arm-linux-gnueabihf-gcc\" --release

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -66,6 +66,8 @@ jobs:
     defaults:
       run:
         working-directory: ./pod-operation
+    env:
+      TARGET: armv7-unknown-linux-gnueabihf
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -74,12 +76,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      
+
       - name: Add target
-        run: rustup target add armv7-unknown-linux-gnueabihf
-      
+        run: rustup target add $TARGET
+
       - name: Install target building dependencies
-        run: sudo apt-get -qq install crossbuild-essential-armhf
+        run: sudo apt-get update && sudo apt-get -qq install crossbuild-essential-armhf
 
       - name: Run cargo test
         run: cargo test
@@ -91,7 +93,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Build Pod Operation Program (debug)
-        run: cargo build --config target.armv7-unknown-linux-gnueabihf.linker=\"arm-linux-gnueabihf-gcc\"
+        run: cargo build --target $TARGET --config target.$TARGET.linker=\"arm-linux-gnueabihf-gcc\"
 
       - name: Build Pod Operation Program (release)
-        run: cargo build --config target.armv7-unknown-linux-gnueabihf.linker=\"arm-linux-gnueabihf-gcc\" --release
+        run: cargo build --target $TARGET --config target.$TARGET.linker=\"arm-linux-gnueabihf-gcc\" --release

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -1,8 +1,9 @@
 # Configuration to cross-compile for Raspberry Pi
+# Uncomment lines as needed
 
 [build]
-target = "armv7-unknown-linux-gnueabihf"
+# target = "armv7-unknown-linux-gnueabihf"
 
 [target.armv7-unknown-linux-gnueabihf]
 # linker = "armv7-unknown-linux-gnueabihf-gcc"
-linker = "arm-none-linux-gnueabihf-gcc"
+# linker = "arm-none-linux-gnueabihf-gcc"

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Configuration to cross-compile for Raspberry Pi
+
+[build]
+target = "armv7-unknown-linux-gnueabihf"
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "armv7-unknown-linux-gnueabihf-gcc"

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -4,4 +4,5 @@
 target = "armv7-unknown-linux-gnueabihf"
 
 [target.armv7-unknown-linux-gnueabihf]
-linker = "armv7-unknown-linux-gnueabihf-gcc"
+# linker = "armv7-unknown-linux-gnueabihf-gcc"
+linker = "arm-none-linux-gnueabihf-gcc"

--- a/pod-operation/Cross.toml
+++ b/pod-operation/Cross.toml
@@ -1,0 +1,2 @@
+[build]
+default-target = "armv7-unknown-linux-gnueabihf"

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -4,9 +4,7 @@ This Rust package is for the main program to be run on the pod.
 The program runs a finite-state machine to operate the pod components
 and acts as a Socket.IO server to communicate with the control station.
 
-## Usage
-
-### First-time Setup
+## First-time Setup
 
 Install cargo-watch
 
@@ -14,10 +12,45 @@ Install cargo-watch
 cargo install cargo-watch
 ```
 
-### Local Development
+Add the build target for the Raspberry Pi
+
+```shell
+rustup target add armv7-unknown-linux-gnueabihf
+```
+
+### Cross-Compilation
+
+Install the compiler for the Raspberry Pi platform
+
+#### macOS
+
+A homebrew formula for macOS cross-compiler toolchains is available
+
+```shell
+brew tap messense/macos-cross-toolchains
+brew install armv7-unknown-linux-gnueabihf
+```
+
+#### Windows
+
+TBD
+
+## Local Development
 
 To locally run the development server with auto-reload
 
 ```shell
 cargo watch -x run
 ```
+
+## Building for Production
+
+To build for production, use the `--release` option
+
+```shell
+cargo build --release
+```
+
+This will compile the project to
+`target/armv7-unknown-linux-gnueabihf/release/pod-operation`
+which can be run on the Raspberry Pi.

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -25,7 +25,7 @@ or [`cross`](https://github.com/cross-rs/cross) can be used to build inside a co
 
 #### macOS
 
-A homebrew formula for macOS cross-compiler toolchains is available
+A Homebrew formula for macOS cross-compiler toolchains is available
 
 ```shell
 brew tap messense/macos-cross-toolchains
@@ -37,7 +37,7 @@ brew install armv7-unknown-linux-gnueabihf
 To cross-compile on Windows and Linux, a different compiler toolchain is needed. From the
 [Arm GNU Toolchain Downloads](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads),
 download and install the **AArch32 GNU/Linux target with hard float (arm-none-linux-gnueabihf)**
-for Windows or Linux.
+for your operating system.
 
 #### Alternative Building Process With `cross`
 
@@ -60,8 +60,9 @@ Next, install the `cross` package.
 cargo install cross
 ```
 
-This is the library that will facilitate cross-compilation without much
-configuration on our end. It requires Docker (or Podman) in order to function.
+This is the library that will facilitate cross-compilation with minimal additional configuration.
+`cross` requires Docker (or Podman) in order to function and will also emulate the ARM architecture
+inside the container using QEMU.
 
 On Linux, if an error appears during build about `GLIBC`, install the `glibc` library.
 

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -31,9 +31,49 @@ brew tap messense/macos-cross-toolchains
 brew install armv7-unknown-linux-gnueabihf
 ```
 
-#### Windows
+#### Windows/Linux
 
-TBD
+For both of these platforms, a different process is necessary.
+
+**Prerequisites**
+
+First, install [Docker](https://docs.docker.com/). You can either install
+Docker Desktop or the more lightweight Docker Engine, which is only available
+on Linux distributions.
+
+**Please note that on Linux, non-sudo users need to be in the `docker` group or
+use rootless Docker.** You can read more about adding yourself to the group
+[here](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
+
+Next, install the [`cross`](https://github.com/cross-rs/cross) package by
+running the below command in the `pod-operation/` directory.
+
+```shell
+cargo install cross --git https://github.com/cross-rs/cross
+```
+
+This is the library that will facilitate cross-compilation without much
+configuration on our end. It requires Docker in order to function.
+
+Ensure that `cross` is now on your `PATH`. Usually, it
+is located in the `.cargo/bin` folder of your home directory, so if `cross` is not in your `PATH`, you can check this directory and add it to `PATH`.
+
+Now run
+
+```shell
+cross build
+```
+
+and the program should build. On Linux, if an error appears about `GLIBC`,
+you may need to install the `glibc` library. You can do this by running
+
+```shell
+# Ubuntu/Debian-based distributions
+sudo apt install glibc
+
+# Arch-based distributions
+sudo pacman -S glibc
+```
 
 ## Local Development
 

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -20,7 +20,8 @@ rustup target add armv7-unknown-linux-gnueabihf
 
 ### Cross-Compilation
 
-Install the compiler for the Raspberry Pi platform
+To compile for the Raspberry Pi target, a specific linker is needed for each operating system,
+or [`cross`](https://github.com/cross-rs/cross) can be used to build inside a container.
 
 #### macOS
 
@@ -33,16 +34,15 @@ brew install armv7-unknown-linux-gnueabihf
 
 #### Windows/Linux
 
-For building natively, a different linker is required from the one
-specified in `.cargo/config.toml`. Instead of `armv7-unknown-linux-gnueabihf-gcc`
-for MacOS, we instead use `arm-none-linux-gnueabihf-gcc`, which can be downloaded
-and installed [here](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
-You will want to select the **AArch32 GNU/Linux target with hard float** to download.
-Then in `.cargo/config.toml`, uncomment the line that has the appropriate linker.
-
+To cross-compile on Windows and Linux, a different compiler toolchain is needed. From the
+[Arm GNU Toolchain Downloads](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads),
+download and install the **AArch32 GNU/Linux target with hard float (arm-none-linux-gnueabihf)**
+for Windows or Linux.
 
 #### Alternative Building Process With `cross`
-For both of these platforms, a different process is necessary.
+
+An alternative to installing cross-compilers is using `cross` to build and run the Rust project
+using containers and emulation. This can be used on any operating system (macOS, Windows, Linux).
 
 **Prerequisites**
 
@@ -54,27 +54,16 @@ on Linux distributions.
 use rootless Docker.** You can read more about adding yourself to the group
 [here](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 
-Next, install the [`cross`](https://github.com/cross-rs/cross) package by
-running the below command in the `pod-operation/` directory.
+Next, install the `cross` package.
 
 ```shell
-cargo install cross --git https://github.com/cross-rs/cross
+cargo install cross
 ```
 
 This is the library that will facilitate cross-compilation without much
-configuration on our end. It requires Docker in order to function.
+configuration on our end. It requires Docker (or Podman) in order to function.
 
-Ensure that `cross` is now on your `PATH`. Usually, it
-is located in the `.cargo/bin` folder of your home directory, so if `cross` is not in your `PATH`, you can check this directory and add it to `PATH`.
-
-Now run
-
-```shell
-cross build
-```
-
-and the program should build. On Linux, if an error appears about `GLIBC`,
-you may need to install the `glibc` library. You can do this by running
+On Linux, if an error appears during build about `GLIBC`, install the `glibc` library.
 
 ```shell
 # Ubuntu/Debian-based distributions
@@ -94,12 +83,22 @@ cargo watch -x run
 
 ## Building for Production
 
-To build for production, use the `--release` option
+Uncomment the arm-linux linker for your operating system in `.cargo/config.toml`.
+
+To build for production, use the `--release` option:
 
 ```shell
-cargo build --release
+cargo build --target armv7-unknown-linux-gnueabihf --release
 ```
 
-This will compile the project to
+Alternatively, use `cross` to compile in a container:
+
+```shell
+cross build --release
+```
+
+Note: the default target is already specified in `Cross.toml`.
+
+Either approach will compile the project to
 `target/armv7-unknown-linux-gnueabihf/release/pod-operation`
 which can be run on the Raspberry Pi.

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -33,6 +33,15 @@ brew install armv7-unknown-linux-gnueabihf
 
 #### Windows/Linux
 
+For building natively, a different linker is required from the one
+specified in `.cargo/config.toml`. Instead of `armv7-unknown-linux-gnueabihf-gcc`
+for MacOS, we instead use `arm-none-linux-gnueabihf-gcc`, which can be downloaded
+and installed [here](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
+You will want to select the **AArch32 GNU/Linux target with hard float** to download.
+Then in `.cargo/config.toml`, uncomment the line that has the appropriate linker.
+
+
+#### Alternative Building Process With `cross`
 For both of these platforms, a different process is necessary.
 
 **Prerequisites**


### PR DESCRIPTION
Resolves #1.

## Changes
- Add Cargo config to set build target platform and linker
- Include setup instructions in README

## Testing
1. Build the project with the ARM target from your personal machine
2. Attempt to run the executable on the Raspberry Pi in lab
3. Observe the program behaves as expected

## Remaining tasks
- [x] Include compiler installation instructions for macOS
- [x] Include compiler installation instructions for Windows
- [x] Include alternative instructions for using [cross](https://github.com/cross-rs/cross)
- [x] Update checks workflow to support cross-compilation