### PR TITLE
Update cross-compilation to aarch64 target

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -67,7 +67,7 @@ jobs:
       run:
         working-directory: ./pod-operation
     env:
-      TARGET: armv7-unknown-linux-gnueabihf
+      TARGET: aarch64-unknown-linux-gnu
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Build Pod Operation Program (debug)
-        run: cargo build --target $TARGET --config target.$TARGET.linker=\"arm-linux-gnueabihf-gcc\"
+        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-unknown-linux-gnu-gcc\"
 
       - name: Build Pod Operation Program (release)
-        run: cargo build --target $TARGET --config target.$TARGET.linker=\"arm-linux-gnueabihf-gcc\" --release
+        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-unknown-linux-gnu-gcc\" --release

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -81,7 +81,7 @@ jobs:
         run: rustup target add $TARGET
 
       - name: Install target building dependencies
-        run: sudo apt-get update && sudo apt-get -qq install crossbuild-essential-armhf
+        run: sudo apt-get update && sudo apt-get -qq install crossbuild-essential-arm64
 
       - name: Run cargo test
         run: cargo test
@@ -93,7 +93,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Build Pod Operation Program (debug)
-        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-unknown-linux-gnu-gcc\"
+        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-linux-gnu-gcc\"
 
       - name: Build Pod Operation Program (release)
-        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-unknown-linux-gnu-gcc\" --release
+        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-linux-gnu-gcc\" --release

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -2,8 +2,8 @@
 # Uncomment lines as needed
 
 [build]
-target = "aarch64-unknown-linux-gnu"
+# target = "aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-gnu]
 # linker = "aarch64-unknown-linux-gnu-gcc"
-linker = "aarch64-none-linux-gnu-gcc"
+# linker = "aarch64-none-linux-gnu-gcc"

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -2,8 +2,8 @@
 # Uncomment lines as needed
 
 [build]
-# target = "armv7-unknown-linux-gnueabihf"
+target = "aarch64-unknown-linux-gnu"
 
-[target.armv7-unknown-linux-gnueabihf]
-# linker = "armv7-unknown-linux-gnueabihf-gcc"
-# linker = "arm-none-linux-gnueabihf-gcc"
+[target.aarch64-unknown-linux-gnu]
+# linker = "aarch64-unknown-linux-gnu-gcc"
+linker = "aarch64-none-linux-gnu-gcc"

--- a/pod-operation/Cross.toml
+++ b/pod-operation/Cross.toml
@@ -1,2 +1,2 @@
 [build]
-default-target = "armv7-unknown-linux-gnueabihf"
+default-target = "aarch64-unknown-linux-gnu"

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -15,7 +15,7 @@ cargo install cargo-watch
 Add the build target for the Raspberry Pi
 
 ```shell
-rustup target add armv7-unknown-linux-gnueabihf
+rustup target add aarch64-unknown-linux-gnu
 ```
 
 ### Cross-Compilation
@@ -29,15 +29,19 @@ A Homebrew formula for macOS cross-compiler toolchains is available
 
 ```shell
 brew tap messense/macos-cross-toolchains
-brew install armv7-unknown-linux-gnueabihf
+brew install aarch64-unknown-linux-gnu
 ```
 
 #### Windows/Linux
 
 To cross-compile on Windows and Linux, a different compiler toolchain is needed. From the
 [Arm GNU Toolchain Downloads](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads),
-download and install the **AArch32 GNU/Linux target with hard float (arm-none-linux-gnueabihf)**
-for your operating system.
+download and install the **AArch64 GNU/Linux target (aarch64-none-linux-gnu)** for your operating
+system.
+
+For Linux operating systems, your distribution may also provide the target via
+its package manager (`apt`, `pacman`, etc.). Please refer to the appropriate
+package repository to verify and install it this way if you wish.
 
 #### Alternative Building Process With `cross`
 

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -88,12 +88,12 @@ cargo watch -x run
 
 ## Building for Production
 
-Uncomment the arm-linux linker for your operating system in `.cargo/config.toml`.
+Uncomment the aarch64 Linux linker for your operating system in `.cargo/config.toml`.
 
 To build for production, use the `--release` option:
 
 ```shell
-cargo build --target armv7-unknown-linux-gnueabihf --release
+cargo build --target aarch64-unknown-linux-gnu --release
 ```
 
 Alternatively, use `cross` to compile in a container:
@@ -105,5 +105,5 @@ cross build --release
 Note: the default target is already specified in `Cross.toml`.
 
 Either approach will compile the project to
-`target/armv7-unknown-linux-gnueabihf/release/pod-operation`
+`target/aarch64-unknown-linux-gnu/release/pod-operation`
 which can be run on the Raspberry Pi.


### PR DESCRIPTION
Resolves #24.

## Changes
- Update `.cargo/config.toml` to use the 64-bit target `aarch64-unknown-linux-gnu` and its respective linker (`aarch64-unknown-linux-gnu-gcc` for MacOS and `aarch64-none-linux-gnu-gcc` for other OS's).
    - The MacOS based one is commented out so that Mac users can simply uncomment and use this linker instead when compiling.
- Update README.md to instruct the reader to download the new target.
- Update GitHub workflow to use new target.

## Testing
- Attempt to build a release version of the program, either via `cross build --release` or `cargo build --release`. Both should run without errors.
- Copy the executable located at `target/aarch64-unknown-linux-gnu-gcc/release/pod-operation` to the Raspberry Pi. Then log into the Pi, either via SSH or other means.
- Make the file executable on the Pi by running `chmod +x ./pod-operation`.
- Run the executable by running `./pod-operation`. Both the blink demo and the socket server should start up properly.