### PR TITLE
Setup pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 
 The control system consists of the pod operation backend and control station client.
 See the respective README files for setup instructions.
+
+## Pre-Commit Hooks
+
+This repository has pre-commit hooks enabled using
+[pre-commit](https://www.npmjs.com/package/pre-commit) that automatically run linters,
+formatters, and tests before commits to ensure functionality.

--- a/control-station/.eslintrc.cjs
+++ b/control-station/.eslintrc.cjs
@@ -24,6 +24,9 @@ module.exports = {
 	},
 	plugins: ["react-refresh"],
 	rules: {
-		"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+		"react-refresh/only-export-components": [
+			"warn",
+			{ allowConstantExport: true },
+		],
 	},
 };

--- a/control-station/.eslintrc.cjs
+++ b/control-station/.eslintrc.cjs
@@ -24,9 +24,6 @@ module.exports = {
 	},
 	plugins: ["react-refresh"],
 	rules: {
-		"react-refresh/only-export-components": [
-			"warn",
-			{ allowConstantExport: true },
-		],
+		"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
 	},
 };

--- a/control-station/.prettierrc
+++ b/control-station/.prettierrc
@@ -1,5 +1,6 @@
 {
 	"useTabs": true,
+	"printWidth": 88,
 	"semi": true,
 	"singleQuote": false
 }

--- a/control-station/index.html
+++ b/control-station/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />

--- a/control-station/package.json
+++ b/control-station/package.json
@@ -8,6 +8,7 @@
 		"build": "tsc && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"format": "prettier --write .",
+		"test": "tsc --noEmit",
 		"preview": "vite preview"
 	},
 	"dependencies": {

--- a/control-station/package.json
+++ b/control-station/package.json
@@ -7,6 +7,7 @@
 		"dev": "vite",
 		"build": "tsc && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+		"format": "prettier --write .",
 		"preview": "vite preview"
 	},
 	"dependencies": {

--- a/control-station/src/main.tsx
+++ b/control-station/src/main.tsx
@@ -6,5 +6,5 @@ import "./index.css";
 ReactDOM.createRoot(document.getElementById("root")!).render(
 	<React.StrictMode>
 		<App />
-	</React.StrictMode>
+	</React.StrictMode>,
 );

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -42,11 +42,11 @@ class PodSocketClient {
 	enable(): void {
 		this.socket.connect();
 		console.debug("Enabling socket event handlers");
-		(Object.entries(this.serverEvents) as Entries<ServerToClientEvents>).forEach(
-			([event, handler]) => {
-				this.socket.on(event, handler);
-			}
-		);
+		(
+			Object.entries(this.serverEvents) as Entries<ServerToClientEvents>
+		).forEach(([event, handler]) => {
+			this.socket.on(event, handler);
+		});
 	}
 
 	disable(): void {

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -42,11 +42,11 @@ class PodSocketClient {
 	enable(): void {
 		this.socket.connect();
 		console.debug("Enabling socket event handlers");
-		(
-			Object.entries(this.serverEvents) as Entries<ServerToClientEvents>
-		).forEach(([event, handler]) => {
-			this.socket.on(event, handler);
-		});
+		(Object.entries(this.serverEvents) as Entries<ServerToClientEvents>).forEach(
+			([event, handler]) => {
+				this.socket.on(event, handler);
+			},
+		);
 	}
 
 	disable(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "hx9-control-system",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "husky": "^9.0.11"
-      },
       "devDependencies": {
         "pre-commit": "^1.2.2"
       }
@@ -51,20 +48,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
-      "bin": {
-        "husky": "bin.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/inherits": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,224 @@
+{
+  "name": "hx9-control-system",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hx9-control-system",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "husky": "^9.0.11"
+      },
+      "devDependencies": {
+        "pre-commit": "^1.2.2"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "hx9-control-system",
-  "version": "1.0.0",
-  "description": "The control system consists of the pod operation backend and control station client. See the respective README files for setup instructions.",
-  "main": "index.js",
-  "devDependencies": {
-    "pre-commit": "^1.2.2"
-  },
-  "scripts": {
-    "format:cs": "cd control-station && npm run format",
-    "format:po": "cd pod-operation && npm run format",
-    "lint:cs": "cd control-station && npm run lint",
-    "lint:po": "cd pod-operation && npm run lint",
-    "test:po": "cd pod-operation && npm run test"
-  },
-  "pre-commit": [
-    "format:cs",
-    "format:po",
-    "lint:cs",
-    "lint:po",
-    "test:po"
-  ],
-  "author": "",
-  "license": "ISC"
+	"name": "hx9-control-system",
+	"version": "1.0.0",
+	"description": "The control system consists of the pod operation backend and control station client. See the respective README files for setup instructions.",
+	"main": "index.js",
+	"devDependencies": {
+		"pre-commit": "^1.2.2"
+	},
+	"scripts": {
+		"format:cs": "cd control-station && npm run format",
+		"format:po": "cd pod-operation && npm run format",
+		"lint:cs": "cd control-station && npm run lint",
+		"lint:po": "cd pod-operation && npm run lint",
+		"test:po": "cd pod-operation && npm run test"
+	},
+	"pre-commit": [
+		"format:cs",
+		"format:po",
+		"lint:cs",
+		"lint:po",
+		"test:po"
+	],
+	"author": "",
+	"license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"format:po",
 		"lint:cs",
 		"lint:po",
+		"test:cs",
 		"test:po"
 	],
 	"author": "UCI HyperXite"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "The control system consists of the pod operation backend and control station client. See the respective README files for setup instructions.",
   "main": "index.js",
-  "dependencies": {
-    "husky": "^9.0.11"
-  },
   "devDependencies": {
     "pre-commit": "^1.2.2"
   },
@@ -17,7 +14,14 @@
     "cargocheck": "cd pod-operation && cargo check && exit 0",
     "cargofmt": "cd pod-operation && cargo fmt && exit 0"
   },
-  "pre-commit": ["prettier", "cargofmt"],
+  "pre-commit": [
+    "tsc",
+    "eslint",
+    "prettier",
+    "cargoclippy",
+    "cargocheck",
+    "cargofmt"
+  ],
   "author": "",
   "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -7,20 +7,18 @@
     "pre-commit": "^1.2.2"
   },
   "scripts": {
-    "tsc": "cd control-station && tsc --noEmit && exit 0",
-    "eslint": "cd control-station && npx eslint . && exit 0",
-    "prettier": "cd control-station && prettier --write . && exit 0",
-    "cargoclippy": "cd pod-operation && cargo clippy && exit 0",
-    "cargocheck": "cd pod-operation && cargo check && exit 0",
-    "cargofmt": "cd pod-operation && cargo fmt && exit 0"
+    "format:cs": "cd control-station && npm run format",
+    "format:po": "cd pod-operation && npm run format",
+    "lint:cs": "cd control-station && npm run lint",
+    "lint:po": "cd pod-operation && npm run lint",
+    "test:po": "cd pod-operation && npm run test"
   },
   "pre-commit": [
-    "tsc",
-    "eslint",
-    "prettier",
-    "cargoclippy",
-    "cargocheck",
-    "cargofmt"
+    "format:cs",
+    "format:po",
+    "lint:cs",
+    "lint:po",
+    "test:po"
   ],
   "author": "",
   "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "pre-commit": "^1.2.2"
   },
   "scripts": {
+    "tsc": "cd control-station && tsc --noEmit && exit 0",
     "eslint": "cd control-station && npx eslint . && exit 0",
     "prettier": "cd control-station && prettier --write . && exit 0",
     "cargoclippy": "cd pod-operation && cargo clippy && exit 0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "hx9-control-system",
+  "version": "1.0.0",
+  "description": "The control system consists of the pod operation backend and control station client. See the respective README files for setup instructions.",
+  "main": "index.js",
+  "dependencies": {
+    "husky": "^9.0.11"
+  },
+  "devDependencies": {
+    "pre-commit": "^1.2.2"
+  },
+  "scripts": {
+    "prettier": "cd control-station && prettier --write . && exit 0",
+    "cargofmt": "cd pod-operation && cargo fmt && exit 0"
+  },
+  "pre-commit": ["prettier", "cargofmt"],
+  "author": "",
+  "license": "ISC"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "pre-commit": "^1.2.2"
   },
   "scripts": {
+    "eslint": "cd control-station && npx eslint . && exit 0",
     "prettier": "cd control-station && prettier --write . && exit 0",
+    "cargoclippy": "cd pod-operation && cargo clippy && exit 0",
+    "cargocheck": "cd pod-operation && cargo check && exit 0",
     "cargofmt": "cd pod-operation && cargo fmt && exit 0"
   },
   "pre-commit": ["prettier", "cargofmt"],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "hx9-control-system",
 	"version": "1.0.0",
 	"description": "The control system consists of the pod operation backend and control station client. See the respective README files for setup instructions.",
-	"main": "index.js",
 	"devDependencies": {
 		"pre-commit": "^1.2.2"
 	},
@@ -11,6 +10,7 @@
 		"format:po": "cd pod-operation && npm run format",
 		"lint:cs": "cd control-station && npm run lint",
 		"lint:po": "cd pod-operation && npm run lint",
+		"test:cs": "cd control-station && npm run test",
 		"test:po": "cd pod-operation && npm run test"
 	},
 	"pre-commit": [
@@ -20,6 +20,5 @@
 		"lint:po",
 		"test:po"
 	],
-	"author": "",
-	"license": "ISC"
+	"author": "UCI HyperXite"
 }

--- a/pod-operation/package.json
+++ b/pod-operation/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "pod-operation",
-  "version": "1.0.0",
-  "description": "This Rust package is for the main program to be run on the pod. The program runs a finite-state machine to operate the pod components and acts as a Socket.IO server to communicate with the control station.",
-  "main": "index.js",
-  "scripts": {
-    "lint": "cargo clippy",
-    "format": "cargo fmt",
-    "test": "cargo test"
-  },
-  "author": "",
-  "license": "ISC"
+	"name": "pod-operation",
+	"version": "1.0.0",
+	"description": "This Rust package is for the main program to be run on the pod. The program runs a finite-state machine to operate the pod components and acts as a Socket.IO server to communicate with the control station.",
+	"main": "index.js",
+	"scripts": {
+		"lint": "cargo clippy",
+		"format": "cargo fmt",
+		"test": "cargo test"
+	},
+	"author": "",
+	"license": "ISC"
 }

--- a/pod-operation/package.json
+++ b/pod-operation/package.json
@@ -2,12 +2,10 @@
 	"name": "pod-operation",
 	"version": "1.0.0",
 	"description": "This Rust package is for the main program to be run on the pod. The program runs a finite-state machine to operate the pod components and acts as a Socket.IO server to communicate with the control station.",
-	"main": "index.js",
 	"scripts": {
 		"lint": "cargo clippy",
 		"format": "cargo fmt",
 		"test": "cargo test"
 	},
-	"author": "",
-	"license": "ISC"
+	"author": "UCI HyperXite"
 }

--- a/pod-operation/package.json
+++ b/pod-operation/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pod-operation",
+  "version": "1.0.0",
+  "description": "This Rust package is for the main program to be run on the pod. The program runs a finite-state machine to operate the pod components and acts as a Socket.IO server to communicate with the control station.",
+  "main": "index.js",
+  "scripts": {
+    "lint": "cargo clippy",
+    "format": "cargo fmt",
+    "test": "cargo test"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This PR uses [`pre-commit`](https://www.npmjs.com/package/pre-commit) to set up pre-commit hooks for the following:

- `control-station/`
    - Prettier
    - ESLint
    - `tsc`
 - `pod-operation/`
    - `cargo fmt`
    - `cargo check`
    - `cargo clippy`
 