### PR TITLE
Add tick interval to FSM run loop

### DIFF
--- a/pod-operation/src/demo.rs
+++ b/pod-operation/src/demo.rs
@@ -3,7 +3,7 @@ use tracing::info;
 use crate::components::pressure_transducer::PressureTransducer;
 use crate::components::signal_light::SignalLight;
 
-pub async fn _blink(mut signal_light: SignalLight) {
+pub async fn blink(mut signal_light: SignalLight) {
 	let mut i = 0;
 
 	info!("Starting blink demo.");


### PR DESCRIPTION
Following from #19/#39, we'll want to limit the tick rate of the FSM to not loop without any sleep time. For demonstration purposes, this is set to 500ms, but in practice, it will likely be much smaller.

## Changes
- Make `run` method async and move incremental behavior to `tick` method
- Use `tokio::time::interval` to set period of run loop
- Reorganize sample emit into `pod_periodic`
- Temporarily restore signal light blink demo

## Testing
1. Temporarily disable RPPAL components (i.e. `SignalLight`, `PressureTransducer`) as needed if not running on a Pi because of #40
2. Start the pod-operation program and control-station GUI
3. Once the socket connection is made, observe the console log "server says 123"