### PR TITLE
Preliminary thermistor abstraction implementation

### DIFF
--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -2,9 +2,9 @@
 # Uncomment lines as needed
 
 [build]
-target = "aarch64-unknown-linux-gnu"
+# target = "aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
+# linker = "aarch64-linux-gnu-gcc"
 # linker = "aarch64-unknown-linux-gnu-gcc"
 # linker = "aarch64-none-linux-gnu-gcc"

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -2,8 +2,9 @@
 # Uncomment lines as needed
 
 [build]
-# target = "aarch64-unknown-linux-gnu"
+target = "aarch64-unknown-linux-gnu"
 
 [target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
 # linker = "aarch64-unknown-linux-gnu-gcc"
 # linker = "aarch64-none-linux-gnu-gcc"

--- a/pod-operation/Cargo.lock
+++ b/pod-operation/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ads1x1x"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b44310e48193933db0cd788961f450a86f35fdad022e4373883fa8e4640488e"
+dependencies = [
+ "embedded-hal 0.2.7",
+ "nb 1.1.0",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +651,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pod-operation"
 version = "0.1.0"
 dependencies = [
+ "ads1x1x",
  "axum",
  "enum-map",
  "ina219",

--- a/pod-operation/Cargo.lock
+++ b/pod-operation/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "enum-map",
  "ina219",
  "lazy_static",
+ "nb 1.1.0",
  "rppal",
  "serde",
  "serde_json",

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -17,3 +17,4 @@ lazy_static = "1.4.0"
 rppal = { version = "0.17.1", features = ["hal"] }
 ina219 = "0.1.0"
 enum-map = "2.7.3"
+ads1x1x = "0.2.2"

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -18,3 +18,4 @@ rppal = { version = "0.17.1", features = ["hal"] }
 ina219 = "0.1.0"
 enum-map = "2.7.3"
 ads1x1x = "0.2.2"
+nb = "1.1.0"

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -1,0 +1,34 @@
+use ads1x1x::ic::{Ads1015, Resolution12Bit};
+use ads1x1x::interface::I2cInterface;
+use ads1x1x::mode::Continuous;
+use ads1x1x::{Ads1x1x, SlaveAddr};
+use rppal::i2c::I2c;
+
+pub struct LimTemperature {
+	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, Continuous>,
+}
+
+impl LimTemperature {
+	pub fn new() -> Self {
+		let i2cdev = I2c::new().unwrap();
+		let adc = Ads1x1x::new_ads1015(i2cdev, SlaveAddr::default());
+		match adc.into_continuous() {
+			Err(ads1x1x::ModeChangeError::I2C(e, _adc)) => {
+				panic!("Error converting ADS1015 to continuous mode: {:?}", e)
+			}
+			Ok(mut adc) => {
+                let _channel_converksion = adc.select_channel(&mut ads1x1x::channel::SingleA0);
+                return LimTemperature { ads1015: adc }
+            }
+		}
+	}
+
+	pub fn cleanup(self) {
+		self.ads1015.destroy_ads1015();
+	}
+
+	pub fn read_pin_a0(&mut self) -> i16 {
+		let value = self.ads1015.read().unwrap();
+		return value;
+	}
+}

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -1,34 +1,35 @@
 use ads1x1x::ic::{Ads1015, Resolution12Bit};
 use ads1x1x::interface::I2cInterface;
-use ads1x1x::mode::Continuous;
-use ads1x1x::{Ads1x1x, SlaveAddr};
+use ads1x1x::mode::OneShot;
+use ads1x1x::ChannelSelection::{SingleA0, SingleA1, SingleA2, SingleA3};
+use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
+use nb::block;
 use rppal::i2c::I2c;
 
 pub struct LimTemperature {
-	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, Continuous>,
+	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, OneShot>,
 }
 
 impl LimTemperature {
 	pub fn new() -> Self {
 		let i2cdev = I2c::new().unwrap();
 		let adc = Ads1x1x::new_ads1015(i2cdev, SlaveAddr::default());
-		match adc.into_continuous() {
-			Err(ads1x1x::ModeChangeError::I2C(e, _adc)) => {
-				panic!("Error converting ADS1015 to continuous mode: {:?}", e)
-			}
-			Ok(mut adc) => {
-                let _channel_converksion = adc.select_channel(&mut ads1x1x::channel::SingleA0);
-                return LimTemperature { ads1015: adc }
-            }
-		}
+		LimTemperature { ads1015: adc }
 	}
 
 	pub fn cleanup(self) {
 		self.ads1015.destroy_ads1015();
 	}
 
-	pub fn read_pin_a0(&mut self) -> i16 {
-		let value = self.ads1015.read().unwrap();
-		return value;
+	pub fn read_pins(&mut self) -> Vec<i16> {
+		let mut read_values: Vec<i16> = Vec::new();
+		let channels = vec![SingleA0, SingleA1, SingleA2, SingleA3];
+
+		for channel in channels {
+			let read = block!(self.ads1015.read(channel)).unwrap();
+			read_values.push(read);
+		}
+
+		read_values
 	}
 }

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -11,9 +11,9 @@ pub struct LimTemperature {
 }
 
 impl LimTemperature {
-	pub fn new() -> Self {
+	pub fn new(device_address: SlaveAddr) -> Self {
 		let i2cdev = I2c::new().unwrap();
-		let adc = Ads1x1x::new_ads1015(i2cdev, SlaveAddr::default());
+		let adc = Ads1x1x::new_ads1015(i2cdev, device_address);
 		LimTemperature { ads1015: adc }
 	}
 

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -21,15 +21,15 @@ impl LimTemperature {
 		self.ads1015.destroy_ads1015();
 	}
 
-	pub fn read_pins(&mut self) -> Vec<i16> {
-		let mut read_values: Vec<i16> = Vec::new();
+	pub fn read_pins(&mut self) -> (i16, i16, i16, i16) {
+		let mut read_values = [0; 4];
 		let channels = vec![SingleA0, SingleA1, SingleA2, SingleA3];
 
-		for channel in channels {
+		for (i, channel) in channels.into_iter().enumerate() {
 			let read = block!(self.ads1015.read(channel)).unwrap();
-			read_values.push(read);
+			read_values[i] = read;
 		}
 
-		read_values
+		read_values.into()
 	}
 }

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -22,14 +22,8 @@ impl LimTemperature {
 	}
 
 	pub fn read_pins(&mut self) -> (i16, i16, i16, i16) {
-		let mut read_values = [0; 4];
-		let channels = vec![SingleA0, SingleA1, SingleA2, SingleA3];
-
-		for (i, channel) in channels.into_iter().enumerate() {
-			let read = block!(self.ads1015.read(channel)).unwrap();
-			read_values[i] = read;
-		}
-
-		read_values.into()
+		[SingleA0, SingleA1, SingleA2, SingleA3]
+			.map(|channel| block!(self.ads1015.read(channel)).unwrap())
+			.into()
 	}
 }

--- a/pod-operation/src/components/mod.rs
+++ b/pod-operation/src/components/mod.rs
@@ -1,2 +1,3 @@
+pub mod lim_temperature;
 pub mod pressure_transducer;
 pub mod signal_light;

--- a/pod-operation/src/demo.rs
+++ b/pod-operation/src/demo.rs
@@ -32,8 +32,15 @@ pub async fn read_pressure_transducer(mut pressure_transducer: PressureTransduce
 pub async fn read_ads1015(mut lim_temperature: LimTemperature) {
 	info!("Starting ADS1015 Demo.");
 
+	let mut i = 0;
 	loop {
-		tokio::time::sleep(std::time::Duration::new(0, 100000000)).await;
-		println!("{}", lim_temperature.read_pin_a0());
+		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+		println!("{:?}", lim_temperature.read_pins());
+		i += 1;
+		if i > 1000 {
+			break;
+		}
 	}
+
+	lim_temperature.cleanup();
 }

--- a/pod-operation/src/demo.rs
+++ b/pod-operation/src/demo.rs
@@ -1,5 +1,6 @@
 use tracing::info;
 
+use crate::components::lim_temperature::LimTemperature;
 use crate::components::pressure_transducer::PressureTransducer;
 use crate::components::signal_light::SignalLight;
 
@@ -25,5 +26,14 @@ pub async fn read_pressure_transducer(mut pressure_transducer: PressureTransduce
 	loop {
 		tokio::time::sleep(std::time::Duration::new(1, 0)).await;
 		println!("{:?}", pressure_transducer.read());
+	}
+}
+
+pub async fn read_ads1015(mut lim_temperature: LimTemperature) {
+	info!("Starting ADS1015 Demo.");
+
+	loop {
+		tokio::time::sleep(std::time::Duration::new(0, 100000000)).await;
+		println!("{}", lim_temperature.read_pin_a0());
 	}
 }

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -8,6 +8,7 @@ mod demo;
 mod state_machine;
 
 use crate::components::pressure_transducer::PressureTransducer;
+use crate::components::lim_temperature::LimTemperature;
 use crate::components::signal_light::SignalLight;
 use crate::state_machine::StateMachine;
 
@@ -22,6 +23,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let pressure_transducer = PressureTransducer::new(0x40);
 	tokio::spawn(demo::read_pressure_transducer(pressure_transducer));
+
+	let ads1015 = LimTemperature::new();
+	tokio::spawn(demo::read_ads1015(ads1015));
 
 	tokio::spawn(async {
 		let mut state_machine = StateMachine::new(io);

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -7,8 +7,8 @@ mod components;
 mod demo;
 mod state_machine;
 
-use crate::components::pressure_transducer::PressureTransducer;
 use crate::components::lim_temperature::LimTemperature;
+use crate::components::pressure_transducer::PressureTransducer;
 use crate::components::signal_light::SignalLight;
 use crate::state_machine::StateMachine;
 
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let pressure_transducer = PressureTransducer::new(0x40);
 	tokio::spawn(demo::read_pressure_transducer(pressure_transducer));
 
-	let ads1015 = LimTemperature::new();
+	let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
 	tokio::spawn(demo::read_ads1015(ads1015));
 
 	tokio::spawn(async {


### PR DESCRIPTION
Resolves #37 through the following:
- Create new `LimTemperature` abstraction in `components/`
- Add simple demo in `demo.rs` that reads from the ADS1015

To test the component individually, comment out the code in `demo.rs` that creates an instance of `PressureTransducer`, as not doing so will cause an I2C error. Build and run the pod operation executable on a Raspberry Pi 4B and observe the values being printed in millivolts.

**Note:** A slight issue is that when the voltage drop across the thermistor approaches smaller values, the readings are off by a certain number of millivolts.