### PR TITLE
Reorganize states and enter actions with enum-map

### DIFF
--- a/control-station/src/components/ControlPanel/ControlPanel.css
+++ b/control-station/src/components/ControlPanel/ControlPanel.css
@@ -16,13 +16,14 @@
 	font-size: 1.5rem;
 	color: white;
 }
-.start {
+
+.run {
 	background-color: rgb(35, 128, 30);
 }
 .stop {
 	background-color: rgb(235, 63, 51);
 }
-.force {
+.halt {
 	background-color: rgb(149, 46, 46);
 }
 .load {

--- a/control-station/src/components/ControlPanel/ControlPanel.tsx
+++ b/control-station/src/components/ControlPanel/ControlPanel.tsx
@@ -5,14 +5,14 @@ function ControlPanel() {
 	const { podSocketClient } = usePodData();
 	return (
 		<div className="controlpanel">
-			<button className="button start" onClick={() => podSocketClient.sendStart()}>
-				Start
+			<button className="button run" onClick={() => podSocketClient.sendRun()}>
+				Run
 			</button>
 			<button className="button stop" onClick={() => podSocketClient.sendStop()}>
 				Stop
 			</button>
-			<button className="button force" onClick={() => podSocketClient.sendForcestop()}>
-				Force Stop
+			<button className="button halt" onClick={() => podSocketClient.sendHalt()}>
+				Halt
 			</button>
 			<button className="button load" onClick={() => podSocketClient.sendLoad()}>
 				Load

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -17,9 +17,9 @@ interface ClientToServerEvents {
 	ping: (data: string, ack: (data: string) => void) => void;
 	greet: (data: string, ack: (data: string) => void) => void;
 	stop: (data: string, ack: (data: string) => void) => void;
-	forcestop: (data: string, ack: (data: string) => void) => void;
+	halt: (data: string, ack: (data: string) => void) => void;
 	load: (data: string, ack: (data: string) => void) => void;
-	start: (data: string, ack: (data: string) => void) => void;
+	run: (data: string, ack: (data: string) => void) => void;
 }
 
 export interface PodData {
@@ -91,8 +91,8 @@ class PodSocketClient {
 		});
 	}
 
-	sendForcestop(): void {
-		this.socket.emit("forcestop", "Hello from client", (ack: string) => {
+	sendHalt(): void {
+		this.socket.emit("halt", "Hello from client", (ack: string) => {
 			console.log(`Server responds to stop with ${ack}`);
 		});
 	}
@@ -103,8 +103,8 @@ class PodSocketClient {
 		});
 	}
 
-	sendStart(): void {
-		this.socket.emit("start", "Hello from client", (ack: string) => {
+	sendRun(): void {
+		this.socket.emit("run", "Hello from client", (ack: string) => {
 			console.log(`Server responds to stop with ${ack}`);
 		});
 	}

--- a/control-station/src/views/Dashboard/Dashboard.tsx
+++ b/control-station/src/views/Dashboard/Dashboard.tsx
@@ -10,9 +10,9 @@ function Dashboard() {
 			<Status />
 			<p>{podData.connected ? "connected" : "disconnected"}</p>
 			<button onClick={() => podSocketClient.sendStop()}>Send Stop</button>
-			<button onClick={() => podSocketClient.sendForcestop()}>Send Forcestop</button>
+			<button onClick={() => podSocketClient.sendHalt()}>Send Halt</button>
 			<button onClick={() => podSocketClient.sendLoad()}>Send Load</button>
-			<button onClick={() => podSocketClient.sendStart()}>Send Start</button>
+			<button onClick={() => podSocketClient.sendRun()}>Send Run</button>
 		</div>
 	);
 }

--- a/pod-operation/Cargo.lock
+++ b/pod-operation/Cargo.lock
@@ -239,6 +239,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +642,7 @@ name = "pod-operation"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "enum-map",
  "ina219",
  "lazy_static",
  "rppal",

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -16,3 +16,4 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 lazy_static = "1.4.0"
 rppal = { version = "0.17.1", features = ["hal"] }
 ina219 = "0.1.0"
+enum-map = "2.7.3"

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -56,9 +56,9 @@ impl StateMachine {
 			info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
 			socket.on("init", StateMachine::handle_init);
 			socket.on("stop", StateMachine::handle_stop);
-			socket.on("forcestop", StateMachine::handle_forcestop);
+			socket.on("forcestop", StateMachine::handle_halt);
 			socket.on("load", StateMachine::handle_load);
-			socket.on("start", StateMachine::handle_start);
+			socket.on("start", StateMachine::handle_run);
 		});
 
 		Self {
@@ -170,10 +170,9 @@ impl StateMachine {
 		Self::modify_state(State::Stopped);
 	}
 
-	fn handle_forcestop(Data(_data): Data<String>, ack: AckSender) {
-		info!("Received forcestop from client");
-		//socket.emit("forcestop", "forcestop").ok();
-		ack.send("forcestop").ok();
+	fn handle_halt(Data(_data): Data<String>, ack: AckSender) {
+		info!("Received halt from client");
+		ack.send("halt").ok();
 		Self::modify_state(State::Halted);
 	}
 
@@ -184,10 +183,10 @@ impl StateMachine {
 		Self::modify_state(State::Load);
 	}
 
-	fn handle_start(Data(_data): Data<String>, ack: AckSender) {
-		info!("Received start from client");
+	fn handle_run(Data(_data): Data<String>, ack: AckSender) {
+		info!("Received run from client");
 		//socket.emit("start", "start").ok();
-		ack.send("start").ok();
+		ack.send("run").ok();
 		Self::modify_state(State::Running);
 	}
 

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use enum_map::{enum_map, EnumMap};
 use lazy_static::lazy_static;
 use socketioxide::extract::{AckSender, Data};
 use socketioxide::{extract::SocketRef, SocketIo};
@@ -11,13 +11,13 @@ use tracing::info;
 
 const TICK_INTERVAL: Duration = Duration::from_millis(500);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, enum_map::Enum)]
 pub enum State {
-	Start,
-	Stop,
-	ForceStop,
-	Load,
 	Init,
+	Load,
+	Running,
+	Stopped,
+	Halted,
 }
 
 #[derive(Debug)]
@@ -38,18 +38,19 @@ lazy_static! {
 
 pub struct StateMachine {
 	state_now: Option<State>,
-	enter_actions: HashMap<State, fn()>,
+	enter_actions: EnumMap<State, fn(&mut Self)>,
 	io: SocketIo,
 }
 
 impl StateMachine {
 	pub fn new(io: SocketIo) -> Self {
-		let mut enter_actions = HashMap::new();
-		enter_actions.insert(State::Init, StateMachine::_enter_init as fn());
-		enter_actions.insert(State::Start, StateMachine::_enter_start as fn());
-		enter_actions.insert(State::Stop, StateMachine::_enter_stop as fn());
-		enter_actions.insert(State::ForceStop, StateMachine::_enter_forcestop as fn());
-		enter_actions.insert(State::Load, StateMachine::_enter_load as fn());
+		let enter_actions = enum_map! {
+			State::Init => StateMachine::_enter_init,
+			State::Load => StateMachine::_enter_load,
+			State::Running => StateMachine::_enter_running,
+			State::Stopped => StateMachine::_enter_stopped,
+			State::Halted => StateMachine::_enter_halted,
+		};
 
 		io.ns("/control-station", |socket: SocketRef| {
 			info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
@@ -94,7 +95,7 @@ impl StateMachine {
 		if self.state_now == Some(State::Init) {
 			Self::_init_periodic();
 		}
-		if self.state_now == Some(State::Start) {
+		if self.state_now == Some(State::Running) {
 			Self::_running_periodic();
 		}
 
@@ -126,37 +127,33 @@ impl StateMachine {
 		//println!("Rolling INIT state");
 	}
 
-	fn _enter_init() {
-		println!("Entering INIT state");
+	/// Run the corresponding enter action for the given state
+	fn enter_state(&mut self, state: &State) {
+		let enter_action = self.enter_actions[*state];
+		enter_action(self);
 	}
 
-	fn _enter_load() {
-		println!("Entering LOAD state");
-		Self::modify_state(State::Init);
+	fn _enter_init(&mut self) {
+		info!("Entering Init state");
 	}
 
-	fn _enter_start() {
-		println!("Entering START state");
+	fn _enter_load(&mut self) {
+		info!("Entering Load state");
 	}
 
-	fn _enter_stop() {
-		println!("Entering STOP state");
-		Self::modify_state(State::Init);
-		println!("State changed to {:?}", Self::read_state());
+	fn _enter_running(&mut self) {
+		info!("Entering Running state");
+		// self.signal_light.enable();
 	}
 
-	fn _enter_forcestop() {
-		println!("Entering FORCESTOP state");
-		Self::modify_state(State::Init);
+	fn _enter_stopped(&mut self) {
+		info!("Entering Stopped state");
+		// self.signal_light.disable();
 	}
 
-	fn enter_state(&self, state: &State) {
-		println!("Entering state: {:?}", state);
-		if let Some(enter_action) = self.enter_actions.get(state) {
-			enter_action();
-		} else {
-			println!("No enter action defined for {:?}", state);
-		}
+	fn _enter_halted(&mut self) {
+		info!("Entering Halted state");
+		// self.hvs.disable()
 	}
 
 	fn handle_init(Data(_data): Data<String>, ack: AckSender) {
@@ -170,14 +167,14 @@ impl StateMachine {
 		info!("Received stop from client");
 		//socket.emit("stop", "stop").ok();
 		ack.send("stop").ok();
-		Self::modify_state(State::Stop);
+		Self::modify_state(State::Stopped);
 	}
 
 	fn handle_forcestop(Data(_data): Data<String>, ack: AckSender) {
 		info!("Received forcestop from client");
 		//socket.emit("forcestop", "forcestop").ok();
 		ack.send("forcestop").ok();
-		Self::modify_state(State::ForceStop);
+		Self::modify_state(State::Halted);
 	}
 
 	fn handle_load(Data(_data): Data<String>, ack: AckSender) {
@@ -191,7 +188,7 @@ impl StateMachine {
 		info!("Received start from client");
 		//socket.emit("start", "start").ok();
 		ack.send("start").ok();
-		Self::modify_state(State::Start);
+		Self::modify_state(State::Running);
 	}
 
 	fn modify_state(new_value: State) {


### PR DESCRIPTION
Following from #39 and as part of #21, we can rename some of the states to identify what the pod is doing/has done rather than naming them after the action message. We can also simplify the correspondence for enter actions by using [enum-map](https://docs.rs/enum-map) rather than `HashMap`. With `EnumMap`, all enum values must have an associated map value which eliminates the need for checking if the key exists. Additionally, `EnumMap` stores the mapping as an array which should be more performant than hashing.

The enter actions were previously just associated functions, but they'll need to manipulate pod components (e.g. the signal light, brakes, and others), so they were changed to actual methods which mutably borrow. The enter actions cannot be tested yet as the actual state transition logic from #39 needs to be fixed while completing #21.

## Changes
- Rename states to better reflect a sense of being rather than an action
- Use enum-map instead of `HashMap` for complete mapping of enter actions
- Make enter actions actual methods instead of associated functions
  - Take mutable references for eventual component usage