### PR TITLE
Modify `PressureTransducer` to add upstream and downstream PT constructors

### DIFF
--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -34,6 +34,18 @@ impl Reference {
 			current_span: current_hi - current_lo,
 		}
 	}
+
+	// The upstream pressure transducer outputs a current between 4 mA and 20 mA
+	// with 0 PSI and 5000 PSI respectively.
+	fn upstream() -> Self {
+		Self::new(0.0, 5000.0, 4.0, 20.0)
+	}
+
+	// The downtream pressure transducer outputs a current between 4 mA and 20 mA
+	// with 0 PSI and 300 PSI respectively.
+	fn downstream() -> Self {
+		Self::new(0.0, 300.0, 4.0, 20.0)
+	}
 }
 
 fn init_ina(device_address: u8) -> INA219<I2c> {
@@ -57,25 +69,18 @@ impl PressureTransducer {
 	// This constructor should be used for INA219s where the address pins are
 	// grounded. That is, the device address is 0x40.
 	pub fn upstream() -> Self {
-		// The upstream pressure transducer outputs a current between 4 mA and 20 mA
-		// with 0 PSI and 300 PSI respectively.
-		let upstream_ref = Reference::new(0.0, 300.0, 4.0, 20.0);
-
 		Self {
 			ina: init_ina(INA219_UPSTREAM_ADDRESS),
-			ref_values: upstream_ref,
+			ref_values: Reference::upstream(),
 		}
 	}
 
 	// This constructor should be used for INA219s where the address pin A0 is
 	// jumped. That is, the device address is 0x41.
 	pub fn downstream() -> Self {
-		// The downtream pressure transducer outputs a current between 4 mA and 20 mA
-		// with 0 PSI and 300 PSI respectively.
-		let downstream_ref = Reference::new(0.0, 300.0, 4.0, 20.0);
 		Self {
 			ina: init_ina(INA219_DOWNSTREAM_ADDRESS),
-			ref_values: downstream_ref,
+			ref_values: Reference::downstream(),
 		}
 	}
 

--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -36,20 +36,16 @@ impl Reference {
 	}
 }
 
-struct CalibratedINA;
+fn init_ina(device_address: u8) -> INA219<I2c> {
+	let device = I2c::new().unwrap();
 
-impl CalibratedINA {
-	fn init_ina(device_address: u8) -> INA219<I2c> {
-		let device = I2c::new().unwrap();
+	let mut ina219 = INA219::new(device, device_address);
+	debug!("Initialized I2C and INA219");
 
-		let mut ina219 = INA219::new(device, device_address);
-		debug!("Initialized I2C and INA219");
+	ina219.calibrate(INA219_CALIBRATION_VALUE).unwrap();
+	debug!("Calibrating INA219");
 
-		ina219.calibrate(INA219_CALIBRATION_VALUE).unwrap();
-		debug!("Calibrating INA219");
-
-		ina219
-	}
+	ina219
 }
 
 pub struct PressureTransducer {
@@ -66,7 +62,7 @@ impl PressureTransducer {
 		let upstream_ref = Reference::new(0.0, 300.0, 4.0, 20.0);
 
 		Self {
-			ina: CalibratedINA::init_ina(INA219_UPSTREAM_ADDRESS),
+			ina: init_ina(INA219_UPSTREAM_ADDRESS),
 			ref_values: upstream_ref,
 		}
 	}
@@ -78,7 +74,7 @@ impl PressureTransducer {
 		// with 0 PSI and 300 PSI respectively.
 		let downstream_ref = Reference::new(0.0, 300.0, 4.0, 20.0);
 		Self {
-			ina: CalibratedINA::init_ina(INA219_DOWNSTREAM_ADDRESS),
+			ina: init_ina(INA219_DOWNSTREAM_ADDRESS),
 			ref_values: downstream_ref,
 		}
 	}

--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -89,7 +89,6 @@ impl PressureTransducer {
 			current_lo,
 			pressure_span,
 			current_span,
-			..
 		} = self.ref_values;
 
 		pressure_lo + pressure_span * (current - current_lo) / current_span

--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -2,13 +2,14 @@ use ina219::INA219;
 use rppal::i2c::I2c;
 use tracing::debug;
 
-pub struct PressureTransducer {
-	ina: INA219<I2c>,
-}
-
 // The calibration value is used to adjust the maximum current measurement
 // and precision of measurements.
 const INA219_CALIBRATION_VALUE: u16 = 0xffff;
+
+// The pod will be using two INA219s, so we'll need to differentiate them
+// via their device address.
+const INA219_UPSTREAM_ADDRESS: u8 = 0x40;
+const INA219_DOWNSTREAM_ADDRESS: u8 = 0x41;
 
 // Even with the calibration values, the readings from the INA219 are not in
 // mA. A scaling factor is needed in order to convert the raw reading to mA and
@@ -17,28 +18,69 @@ const INA219_CALIBRATION_VALUE: u16 = 0xffff;
 // found in the INA219 datasheet.
 const INA219_SCALING_VALUE: f32 = 160.0;
 
-// The pressure transducer outputs a current between 4 mA and 20 mA with 0 PSI
-// and 300 PSI respectively. Assuming a linear interpolation, a 1 mA increase
-// results in a 18.75 PSI increase.
-const REF_CURRENT_LOW: f32 = 4.0;
-const REF_CURRENT_HIGH: f32 = 20.0;
-const REF_PRESSURE_LOW: f32 = 0.0;
-const REF_PRESSURE_HIGH: f32 = 300.0;
+struct Reference {
+	pressure_lo: f32,
+	pressure_hi: f32,
+	current_lo: f32,
+	current_hi: f32,
+}
 
-const REF_CURRENT_SPAN: f32 = REF_CURRENT_HIGH - REF_CURRENT_LOW;
-const REF_PRESSURE_SPAN: f32 = REF_PRESSURE_HIGH - REF_PRESSURE_LOW;
+// The upstream pressure transducer outputs a current between 4 mA and 20 mA
+// with 0 PSI and 300 PSI respectively.
+const UPSTREAM_REF: Reference = Reference {
+	pressure_lo: 0.0,
+	pressure_hi: 300.0,
+	current_lo: 4.0,
+	current_hi: 20.0,
+};
 
-impl PressureTransducer {
-	pub fn new(ina219_addr: u8) -> Self {
+// The downtream pressure transducer outputs a current between 4 mA and 20 mA
+// with 0 PSI and 300 PSI respectively.
+const DOWNSTREAM_REF: Reference = Reference {
+	pressure_lo: 0.0,
+	pressure_hi: 300.0,
+	current_lo: 4.0,
+	current_hi: 20.0,
+};
+
+struct CalibratedINA;
+
+impl CalibratedINA {
+	fn init_ina(device_address: u8) -> INA219<I2c> {
 		let device = I2c::new().unwrap();
 
-		let mut ina219 = INA219::new(device, ina219_addr);
+		let mut ina219 = INA219::new(device, device_address);
 		debug!("Initialized I2C and INA219");
 
 		ina219.calibrate(INA219_CALIBRATION_VALUE).unwrap();
 		debug!("Calibrating INA219");
 
-		PressureTransducer { ina: ina219 }
+		ina219
+	}
+}
+
+pub struct PressureTransducer {
+	ina: INA219<I2c>,
+	ref_measurements: Reference,
+}
+
+impl PressureTransducer {
+	// This constructor should be used for INA219s where the address pins are
+	// grounded. That is, the device address is 0x40.
+	pub fn new() -> Self {
+		Self {
+			ina: CalibratedINA::init_ina(INA219_UPSTREAM_ADDRESS),
+			ref_measurements: UPSTREAM_REF,
+		}
+	}
+
+	// This constructor should be used for INA219s where the address pin A0 is
+	// jumped. That is, the device address is 0x41.
+	pub fn new_a0() -> Self {
+		Self {
+			ina: CalibratedINA::init_ina(INA219_DOWNSTREAM_ADDRESS),
+			ref_measurements: DOWNSTREAM_REF,
+		}
 	}
 
 	// Read current from the INA219 and apply a scaling factor to translate
@@ -46,7 +88,15 @@ impl PressureTransducer {
 	pub fn read(&mut self) -> f32 {
 		let current = self.read_current();
 
-		REF_PRESSURE_LOW + REF_PRESSURE_SPAN * (current - REF_CURRENT_LOW) / REF_CURRENT_SPAN
+		let Reference {
+			pressure_lo,
+			pressure_hi,
+			current_lo,
+			current_hi,
+		} = self.ref_measurements;
+
+		pressure_lo
+			+ (pressure_hi - pressure_lo) * (current - current_lo) / (current_hi - current_lo)
 	}
 
 	// Read from the INA219 and divide the reading by a scalar factor to

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -21,8 +21,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let signal_light = SignalLight::new();
 	tokio::spawn(demo::blink(signal_light));
 
-	let pressure_transducer = PressureTransducer::new(0x40);
+	let pressure_transducer = PressureTransducer::new();
 	tokio::spawn(demo::read_pressure_transducer(pressure_transducer));
+
+	let pressure_transducer2 = PressureTransducer::new_a0();
+	tokio::spawn(demo::read_pressure_transducer(pressure_transducer2));
 
 	let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
 	tokio::spawn(demo::read_ads1015(ads1015));

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -21,11 +21,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let signal_light = SignalLight::new();
 	tokio::spawn(demo::blink(signal_light));
 
-	let pressure_transducer = PressureTransducer::new();
-	tokio::spawn(demo::read_pressure_transducer(pressure_transducer));
+	let upstream_pressure_transducer = PressureTransducer::upstream();
+	tokio::spawn(demo::read_pressure_transducer(upstream_pressure_transducer));
 
-	let pressure_transducer2 = PressureTransducer::new_a0();
-	tokio::spawn(demo::read_pressure_transducer(pressure_transducer2));
+	let downstream_pressure_transducer = PressureTransducer::downstream();
+	tokio::spawn(demo::read_pressure_transducer(
+		downstream_pressure_transducer,
+	));
 
 	let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
 	tokio::spawn(demo::read_ads1015(ads1015));


### PR DESCRIPTION
Since the pod is using two PTs (upstream and downstream), we can keep the `PressureTransducer` struct simple by only providing two constructors: one that uses the default address of `0x40` and the other that uses the address `0x41` (i.e. when A0 is jumped).

The reference pressure and current constants themselves will be different for the downstream PT compared to the upstream one, so they have been moved into struct fields. However, the values of the constants for the downstream PT have not been confirmed yet. I will reach out to Braking ad update the code once they have been decided.