### PR TITLE
Add function to convert thermistor voltage readings from ADS1015 to Celsius

### DIFF
--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -10,11 +10,11 @@ use rppal::i2c::I2c;
 // connected to a thermistor, with the ADS1015 is measuring the node connecting
 // the two (a voltage divider circuit).
 
-const DIVIDER_RESISTANCE: f32 = 22000.0; // Resistance used in voltage divider circuit
-const V_IN: f32 = 5.0; // Voltage provided to voltage divider circuit
-const BETA: f32 = 3950.0; // Constant used in voltage to temperature conversion process
-const R_0: f32 = 10000.0; // Resistance of thermistor at room temperature
-const ROOM_TEMP: f32 = 298.15; // Room temperature in Kelvins (25 degrees C)
+const DIVIDER_RESISTANCE: f32 = 22000.0; // Ohms
+const V_IN: f32 = 5.0; // Volts
+const BETA: f32 = 3950.0; // Kelvins
+const R_0: f32 = 10000.0; // Ohms
+const ROOM_TEMP: f32 = 298.15; // Kelvins
 
 fn voltage_to_temp(voltage: i16) -> f32 {
 	let voltage = f32::from(voltage) / 1000.0;

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -6,6 +6,19 @@ use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
 use nb::block;
 use rppal::i2c::I2c;
 
+const DIVIDER_RESISTANCE: f32 = 22000.0;
+const VCC: f32 = 5.0;
+const BETA: f32 = 3950.0;
+const R_0: f32 = 10000.0;
+const ROOM_TEMP: f32 = 298.15;
+
+fn voltage_to_temp(voltage: i16) -> f32 {
+	let voltage = f32::from(voltage) / 1000.0;
+	let thermistor_resistance: f32 = (voltage * DIVIDER_RESISTANCE) / (VCC - voltage);
+	let r_inf = R_0 * std::f32::consts::E.powf(-BETA / ROOM_TEMP);
+	(BETA / (thermistor_resistance / r_inf).ln()) - 273.15
+}
+
 pub struct LimTemperature {
 	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, OneShot>,
 }
@@ -21,9 +34,10 @@ impl LimTemperature {
 		self.ads1015.destroy_ads1015();
 	}
 
-	pub fn read_pins(&mut self) -> (i16, i16, i16, i16) {
+	pub fn read_pins(&mut self) -> (f32, f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
 			.map(|channel| block!(self.ads1015.read(channel)).unwrap())
+			.map(voltage_to_temp)
 			.into()
 	}
 }

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -6,17 +6,18 @@ use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
 use nb::block;
 use rppal::i2c::I2c;
 
-const DIVIDER_RESISTANCE: f32 = 22000.0;
-const VCC: f32 = 5.0;
-const BETA: f32 = 3950.0;
-const R_0: f32 = 10000.0;
-const ROOM_TEMP: f32 = 298.15;
+const DIVIDER_RESISTANCE: f32 = 22000.0; // Resistance used in voltage divider circuit
+const V_IN: f32 = 5.0; // Voltage provided to voltage divider circuit
+const BETA: f32 = 3950.0; // Constant used in voltage to temperature conversion process
+const R_0: f32 = 10000.0; // Resistance of thermistor at room temperature
+const ROOM_TEMP: f32 = 298.15; // Room temperature in Kelvins (25 degrees C)
 
 fn voltage_to_temp(voltage: i16) -> f32 {
 	let voltage = f32::from(voltage) / 1000.0;
-	let thermistor_resistance: f32 = (voltage * DIVIDER_RESISTANCE) / (VCC - voltage);
+	let thermistor_resistance = (voltage * DIVIDER_RESISTANCE) / (V_IN - voltage);
 	let r_inf = R_0 * std::f32::consts::E.powf(-BETA / ROOM_TEMP);
-	(BETA / (thermistor_resistance / r_inf).ln()) - 273.15
+	let temp_kelvins = BETA / (thermistor_resistance / r_inf).ln();
+	temp_kelvins - 273.15
 }
 
 pub struct LimTemperature {

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -6,6 +6,8 @@ use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
 use nb::block;
 use rppal::i2c::I2c;
 
+const C_TO_K_CONVERSION: f32 = 273.15;
+
 // These constants assume that 5 volts is provided to a 22k Ohm resistor
 // connected to a thermistor, with the ADS1015 is measuring the node connecting
 // the two (a voltage divider circuit).
@@ -14,14 +16,14 @@ const DIVIDER_RESISTANCE: f32 = 22000.0; // Ohms
 const V_IN: f32 = 5.0; // Volts
 const BETA: f32 = 3950.0; // Kelvins
 const R_0: f32 = 10000.0; // Ohms
-const ROOM_TEMP: f32 = 298.15; // Kelvins
+const ROOM_TEMP: f32 = 25.0 + C_TO_K_CONVERSION; // Kelvins
 
 fn voltage_to_temp(voltage: i16) -> f32 {
 	let voltage = f32::from(voltage) / 1000.0;
 	let thermistor_resistance = (voltage * DIVIDER_RESISTANCE) / (V_IN - voltage);
 	let r_inf = R_0 * std::f32::consts::E.powf(-BETA / ROOM_TEMP);
 	let temp_kelvins = BETA / (thermistor_resistance / r_inf).ln();
-	temp_kelvins - 273.15
+	temp_kelvins - C_TO_K_CONVERSION
 }
 
 pub struct LimTemperature {

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -6,6 +6,10 @@ use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
 use nb::block;
 use rppal::i2c::I2c;
 
+// These constants assume that 5 volts is provided to a 22k Ohm resistor
+// connected to a thermistor, with the ADS1015 is measuring the node connecting
+// the two (a voltage divider circuit).
+
 const DIVIDER_RESISTANCE: f32 = 22000.0; // Resistance used in voltage divider circuit
 const V_IN: f32 = 5.0; // Voltage provided to voltage divider circuit
 const BETA: f32 = 3950.0; // Constant used in voltage to temperature conversion process
@@ -35,7 +39,7 @@ impl LimTemperature {
 		self.ads1015.destroy_ads1015();
 	}
 
-	pub fn read_pins(&mut self) -> (f32, f32, f32, f32) {
+	pub fn read_lim_temps(&mut self) -> (f32, f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
 			.map(|channel| block!(self.ads1015.read(channel)).unwrap())
 			.map(voltage_to_temp)

--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -86,7 +86,7 @@ impl PressureTransducer {
 
 	// Read current from the INA219 and apply a scaling factor to translate
 	// the current reading to PSI.
-	pub fn read(&mut self) -> f32 {
+	pub fn read_pressure(&mut self) -> f32 {
 		let current = self.read_current();
 
 		let Reference {

--- a/pod-operation/src/demo.rs
+++ b/pod-operation/src/demo.rs
@@ -25,7 +25,7 @@ pub async fn read_pressure_transducer(mut pressure_transducer: PressureTransduce
 
 	loop {
 		tokio::time::sleep(std::time::Duration::new(1, 0)).await;
-		println!("{:?}", pressure_transducer.read());
+		println!("{:?}", pressure_transducer.read_pressure());
 	}
 }
 

--- a/pod-operation/src/demo.rs
+++ b/pod-operation/src/demo.rs
@@ -35,7 +35,7 @@ pub async fn read_ads1015(mut lim_temperature: LimTemperature) {
 	let mut i = 0;
 	loop {
 		tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-		println!("{:?}", lim_temperature.read_pins());
+		println!("{:?}", lim_temperature.read_lim_temps());
 		i += 1;
 		if i > 1000 {
 			break;


### PR DESCRIPTION
Resolves the rest of #37 by adding a new function to convert voltage readings from the ADS1015 to a temperature reading in Celsius. This assumes that 5 volts is provided to a 22k Ohm resistor connected to a thermistor, with the ADS1015 is measuring the node connecting the two (a voltage divider circuit).