### PR TITLE
Implement proper state transition model

### DIFF
--- a/pod-operation/Cargo.lock
+++ b/pod-operation/Cargo.lock
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "engineioxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b303078277e24915ec769f3bf8359964c5a05d341f1f44e1eb332b202e45aaf8"
+checksum = "a2cb8b649570e8ed01de4d938d10eb8b41103a16485397a37be921a6710d8dfa"
 dependencies = [
  "base64",
  "bytes",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -310,15 +310,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -327,15 +327,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -344,21 +344,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -655,8 +655,8 @@ dependencies = [
  "axum",
  "enum-map",
  "ina219",
- "lazy_static",
  "nb 1.1.0",
+ "once_cell",
  "rppal",
  "serde",
  "serde_json",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97855ef2f270f9c1cd3116eec1c1a9dab7fed8d51a3c7e3b611ad8a216024b53"
+checksum = "6bbb4f207f50771008b68e4246ae6193b771f46362839f9f9fb29fbfdfbf2e3d"
 dependencies = [
  "engineioxide",
  "futures",

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -6,16 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-socketioxide = "0.7.2"
+socketioxide = "0.7.3"
 axum = "0.6.20"
 tokio = { version = "1.34.0", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-lazy_static = "1.4.0"
+enum-map = "2.7.3"
+once_cell = "1.19.0"
+
 rppal = { version = "0.17.1", features = ["hal"] }
 ina219 = "0.1.0"
-enum-map = "2.7.3"
 ads1x1x = "0.2.2"
 nb = "1.1.0"

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -1,10 +1,10 @@
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use enum_map::{enum_map, EnumMap};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use socketioxide::extract::AckSender;
 use socketioxide::{extract::SocketRef, SocketIo};
+use tokio::sync::Mutex;
 use tracing::info;
 
 // use crate::components::signal_light::SignalLight;
@@ -20,30 +20,18 @@ pub enum State {
 	Halted,
 }
 
-#[derive(Debug)]
-pub struct CurrentState {
-	pub value: Option<State>,
-}
-
-impl CurrentState {
-	pub fn new(value: Option<State>) -> Self {
-		CurrentState { value }
-	}
-}
-
-lazy_static! {
-	pub static ref GLOBAL_STATE: Arc<Mutex<CurrentState>> =
-		Arc::new(Mutex::new(CurrentState::new(None)));
-}
-
 pub struct StateMachine {
-	state_now: Option<State>,
+	last_state: State,
+	state: &'static Mutex<State>,
 	enter_actions: EnumMap<State, fn(&mut Self)>,
+	state_transitions: EnumMap<State, Option<fn(&mut Self) -> State>>,
 	io: SocketIo,
 }
 
 impl StateMachine {
 	pub fn new(io: SocketIo) -> Self {
+		static STATE: Lazy<Mutex<State>> = Lazy::new(|| Mutex::new(State::Init));
+
 		let enter_actions = enum_map! {
 			State::Init => StateMachine::_enter_init,
 			State::Load => StateMachine::_enter_load,
@@ -52,17 +40,35 @@ impl StateMachine {
 			State::Halted => StateMachine::_enter_halted,
 		};
 
+		let state_transitions = enum_map! {
+			State::Init => None,
+			State::Load => Some(StateMachine::_load_periodic as fn(&mut Self) -> State),
+			State::Running => Some(StateMachine::_running_periodic as fn(&mut Self) -> State),
+			State::Stopped => None,
+			State::Halted => None,
+		};
+
 		io.ns("/control-station", |socket: SocketRef| {
 			info!("Socket.IO connected: {:?} {:?}", socket.ns(), socket.id);
-			socket.on("load", StateMachine::handle_load);
-			socket.on("start", StateMachine::handle_run);
-			socket.on("stop", StateMachine::handle_stop);
-			socket.on("forcestop", StateMachine::handle_halt);
+			socket.on("load", |ack: AckSender| async {
+				Self::handle_load(&STATE, ack).await;
+			});
+			socket.on("run", |ack: AckSender| async {
+				Self::handle_run(&STATE, ack).await;
+			});
+			socket.on("stop", |ack: AckSender| async {
+				Self::handle_stop(&STATE, ack).await;
+			});
+			socket.on("halt", |ack: AckSender| async {
+				Self::handle_halt(&STATE, ack).await;
+			});
 		});
 
 		Self {
-			state_now: None,
+			last_state: State::Init,
+			state: &STATE,
 			enter_actions,
+			state_transitions,
 			io,
 		}
 	}
@@ -76,37 +82,25 @@ impl StateMachine {
 		}
 	}
 
+	/// Tick the state machine by running the transition for the current state
+	/// and actions for when entering a new state
 	async fn tick(&mut self) {
-		let last_state = Arc::new(Mutex::new(self.state_now));
+		// Acquire lock for state to prevent socket handlers from overwriting
+		let mut state = self.state.lock().await;
 
-		if self.state_now != *last_state.lock().unwrap() {
-			println!(
-				"State changed from {:?} to {:?}",
-				*last_state.lock().unwrap(),
-				Self::read_state()
-			);
-			self.enter_state(&self.state_now.unwrap());
+		// Run enter action when entering a new state
+		if *state != self.last_state {
+			info!("State changed from {:?} to {:?}", self.last_state, state);
+			self.enter_state(&*state);
 		}
-		if let Some(state) = Self::read_state() {
-			Self::modify_state(state);
-		}
-		let next_state = self.state_now;
-		if self.state_now == Some(State::Init) {
-			Self::_init_periodic();
-		}
-		if self.state_now == Some(State::Running) {
-			Self::_running_periodic();
-		}
-
-		*last_state.lock().unwrap() = self.state_now;
 
 		self.pod_periodic();
 
-		if Self::read_state().is_none() {
-			self.state_now = next_state;
-		} else {
-			self.state_now = Self::read_state();
-		}
+		// Proceed to the next state by transition
+		let next_state = self.run_state_transition(*state);
+		self.last_state = *state;
+		*state = next_state;
+		// state is dropped, releasing the lock
 	}
 
 	/// Perform operations on every FSM tick
@@ -118,18 +112,19 @@ impl StateMachine {
 			.ok();
 	}
 
-	fn _running_periodic() {
-		//println!("Rolling START state");
-	}
-
-	fn _init_periodic() {
-		//println!("Rolling INIT state");
-	}
-
 	/// Run the corresponding enter action for the given state
 	fn enter_state(&mut self, state: &State) {
 		let enter_action = self.enter_actions[*state];
 		enter_action(self);
+	}
+
+	/// Run the transition function for a given state if it exists.
+	/// Otherwise, remain in the same state.
+	fn run_state_transition(&mut self, state: State) -> State {
+		match self.state_transitions[state] {
+			Some(state_transition) => state_transition(self),
+			None => state,
+		}
 	}
 
 	fn _enter_init(&mut self) {
@@ -155,42 +150,50 @@ impl StateMachine {
 		// self.hvs.disable()
 	}
 
-	fn handle_load(ack: AckSender) {
+	/// Perform operations when the pod is loading
+	fn _load_periodic(&mut self) -> State {
+		info!("Rolling Load state");
+		State::Load
+	}
+
+	/// Perform operations when the pod is running
+	fn _running_periodic(&mut self) -> State {
+		info!("Rolling Running state");
+		State::Running
+	}
+
+	// To avoid conflicts with the state-transition model,
+	// each of these event handlers must wait for an ongoing transition to complete
+	// by awaiting the mutex lock to be acquired.
+	// Tokio::sync::mutex uses a fairness queue to ensure in-order acquisition.
+	// The acknowledgement is then sent after the state is updated.
+
+	async fn handle_load(state: &Mutex<State>, ack: AckSender) {
 		info!("Received load from client");
+		let mut state = state.lock().await;
+		*state = State::Load;
 		ack.send("load").ok();
-		Self::modify_state(State::Load);
 	}
 
-	fn handle_run(ack: AckSender) {
-		info!("Received run from client");
-		//socket.emit("start", "start").ok();
+	async fn handle_run(state: &Mutex<State>, ack: AckSender) {
+		info!("Received start from client");
+
+		let mut state = state.lock().await;
+		*state = State::Running;
 		ack.send("run").ok();
-		Self::modify_state(State::Running);
 	}
 
-	fn handle_stop(ack: AckSender) {
+	async fn handle_stop(state: &Mutex<State>, ack: AckSender) {
 		info!("Received stop from client");
+		let mut state = state.lock().await;
+		*state = State::Stopped;
 		ack.send("stop").ok();
-		Self::modify_state(State::Stopped);
 	}
 
-	fn handle_halt(ack: AckSender) {
+	async fn handle_halt(state: &Mutex<State>, ack: AckSender) {
 		info!("Received halt from client");
+		let mut state = state.lock().await;
+		*state = State::Halted;
 		ack.send("halt").ok();
-		Self::modify_state(State::Halted);
-	}
-
-	fn modify_state(new_value: State) {
-		if let Ok(mut state) = GLOBAL_STATE.lock() {
-			state.value = Some(new_value);
-		}
-	}
-
-	fn read_state() -> Option<State> {
-		if let Ok(state) = GLOBAL_STATE.lock() {
-			state.value
-		} else {
-			None
-		}
 	}
 }


### PR DESCRIPTION
In #39, some portions of handling the FSM state were added, but there was a global state value used along with a `state_now` field in `StateMachine`. To have a single source of truth, these can be combined into a single `state` field in `StateMachine`. However, the Socket message handlers require all captured variables to have `static` lifetime, so if we wanted the handler functions to be struct methods, the entire state machine instance would need to have `static` lifetime, but the state machine instance also needs to be mutable for the `run` method to operate peripheral components, and [mutable statics](https://doc.rust-lang.org/reference/items/static-items.html#mutable-statics) are unsafe. To avoid this, the state is declared as a static variable within `StateMachine::new`, and references are borrowed in the associated message handler functions which do not borrow `self`.

For actual decision logic, transition functions are added to determine the next operational state. To avoid conflicting with any pod action messages, a mutex is used to ensure only one task can access `self.state` at a time. In particular, we can use [tokio::sync::Mutex](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html) which has a FIFO queue for fairness, making sure the message handlers can set the state only after an ongoing state transition completes. Additionally, the preliminary transition logic added in #39 did not properly account for entering new states, so a new `last_state` field was added to properly track this.

Resolves #21.

## Changes
- Update to [socketioxide v0.7.3](https://github.com/Totodore/socketioxide/releases/tag/v0.7.3) to use `async` message handlers
- Replace `lazy_static` with [`once_cell`](https://docs.rs/once_cell) to have non-global lazy static
- Remove unnecessary `CurrentState` struct
- Merge global state and `state_now` field into single `state` field
- Use Tokio's mutex to implement locking for fair synchronization
- Fix logic detecting when entering a new state
  - Store `last_state` as field and compare with mutex value
- Use functional transition model to determine next state
  - Create another `EnumMap` to store optional transition functions

## Testing
1. Temporarily disable the RPPAL components or use `cross run` with port forwarding to run the `pod-operation` program because of #40
2. Load the control-station GUI
3. Use the control panel buttons to alter the state of the pod
4. Observe the state machine properly transitions to states as indicated by the info messages
    - E.g. `State changed from Init to Running`, `Entering Running state`, `Rolling Running state`, etc.