### PR TITLE
Integrate distance threshold with FSM

### DIFF
--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -38,7 +38,7 @@ impl WheelEncoder {
 			self.counter += 1.0;
 
 			let current_time = Instant::now();
-			let distance = (self.counter / 18.0) * 3.28084;
+			let distance = (self.counter / 16.0) * 3.0;
 			let velocity_elapsed = current_time
 				.duration_since(self.last_velocity_time)
 				.as_secs_f32();
@@ -54,7 +54,7 @@ impl WheelEncoder {
 		self.a_last_read = a_state;
 		self.b_last_read = b_state;
 
-		(self.counter / 18.0) * 3.28084
+		(self.counter / 16.0) * 3.0
 	}
 
 	pub fn _reset(&mut self) {

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -38,7 +38,7 @@ impl WheelEncoder {
 			self.counter += 1.0;
 
 			let current_time = Instant::now();
-			let distance = (self.counter * 5.0) / 1000.0;
+			let distance = self.counter / 18.0;
 			let velocity_elapsed = current_time
 				.duration_since(self.last_velocity_time)
 				.as_secs_f32();
@@ -54,7 +54,7 @@ impl WheelEncoder {
 		self.a_last_read = a_state;
 		self.b_last_read = b_state;
 
-		(self.counter * 5.0) / 1000.0
+		self.counter / 18.0
 	}
 
 	pub fn _reset(&mut self) {

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -38,7 +38,7 @@ impl WheelEncoder {
 			self.counter += 1.0;
 
 			let current_time = Instant::now();
-			let distance = self.counter / 18.0;
+			let distance = (self.counter / 18.0) * 3.28084;
 			let velocity_elapsed = current_time
 				.duration_since(self.last_velocity_time)
 				.as_secs_f32();
@@ -54,7 +54,7 @@ impl WheelEncoder {
 		self.a_last_read = a_state;
 		self.b_last_read = b_state;
 
-		self.counter / 18.0
+		(self.counter / 18.0) * 3.28084
 	}
 
 	pub fn _reset(&mut self) {

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use crate::components::wheel_encoder::WheelEncoder;
 use enum_map::{enum_map, EnumMap};
 use once_cell::sync::Lazy;
 use socketioxide::extract::AckSender;
@@ -9,9 +8,10 @@ use tokio::sync::Mutex;
 use tracing::info;
 
 // use crate::components::signal_light::SignalLight;
+use crate::components::wheel_encoder::WheelEncoder;
 
 const TICK_INTERVAL: Duration = Duration::from_millis(10);
-const ENCODER_LIMIT: f32 = 37.0;
+const STOP_THRESHOLD: f32 = 37.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, enum_map::Enum)]
 pub enum State {
@@ -166,7 +166,7 @@ impl StateMachine {
 	fn _running_periodic(&mut self) -> State {
 		info!("Rolling Running state");
 		let encoder_value = self.wheel_encoder.read(); // Read the encoder value
-		if encoder_value > ENCODER_LIMIT {
+		if encoder_value > STOP_THRESHOLD {
 			return State::Stopped;
 		}
 		println!("Encoder: {}", encoder_value);

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -170,7 +170,7 @@ impl StateMachine {
 			return State::Stopped;
 		}
 		println!("Encoder: {}", encoder_value);
-		return State::Running;
+		State::Running
 	}
 
 	// To avoid conflicts with the state-transition model,

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -1,17 +1,16 @@
 use std::time::Duration;
 
+use crate::components::wheel_encoder::WheelEncoder;
 use enum_map::{enum_map, EnumMap};
 use once_cell::sync::Lazy;
 use socketioxide::extract::AckSender;
 use socketioxide::{extract::SocketRef, SocketIo};
 use tokio::sync::Mutex;
 use tracing::info;
-use crate::components::wheel_encoder::WheelEncoder;
-
 
 // use crate::components::signal_light::SignalLight;
 
-const TICK_INTERVAL: Duration = Duration::from_millis(500);
+const TICK_INTERVAL: Duration = Duration::from_millis(10);
 const ENCODER_LIMIT: f32 = 37.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, enum_map::Enum)]
@@ -117,7 +116,6 @@ impl StateMachine {
 			.unwrap()
 			.emit("pong", "123")
 			.ok();
-
 	}
 
 	/// Run the corresponding enter action for the given state
@@ -168,9 +166,9 @@ impl StateMachine {
 	fn _running_periodic(&mut self) -> State {
 		info!("Rolling Running state");
 		let encoder_value = self.wheel_encoder.read(); // Read the encoder value
-        if encoder_value > ENCODER_LIMIT {
-            return State::Stopped;
-        }
+		if encoder_value > ENCODER_LIMIT {
+			return State::Stopped;
+		}
 		println!("Encoder: {}", encoder_value);
 		return State::Running;
 	}


### PR DESCRIPTION
Stop the pod when reaching the completion distance threshold. Uses placeholder distance conversion and threshold values for now. Resolves #45.