### PR TITLE
Operate brakes during state changes

### DIFF
--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 use tracing::info;
 
 // use crate::components::signal_light::SignalLight;
+use crate::components::brakes::Brakes;
 
 const TICK_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -28,6 +29,7 @@ pub struct StateMachine {
 	enter_actions: EnumMap<State, fn(&mut Self)>,
 	state_transitions: EnumMap<State, Option<StateTransition>>,
 	io: SocketIo,
+	brakes: Brakes,
 }
 
 impl StateMachine {
@@ -72,6 +74,7 @@ impl StateMachine {
 			enter_actions,
 			state_transitions,
 			io,
+			brakes: Brakes::new(),
 		}
 	}
 
@@ -135,21 +138,25 @@ impl StateMachine {
 
 	fn _enter_load(&mut self) {
 		info!("Entering Load state");
+		self.brakes.disengage();
 	}
 
 	fn _enter_running(&mut self) {
 		info!("Entering Running state");
 		// self.signal_light.enable();
+		self.brakes.disengage();
 	}
 
 	fn _enter_stopped(&mut self) {
 		info!("Entering Stopped state");
 		// self.signal_light.disable();
+		self.brakes.engage();
 	}
 
 	fn _enter_halted(&mut self) {
 		info!("Entering Halted state");
 		// self.hvs.disable()
+		self.brakes.engage();
 	}
 
 	/// Perform operations when the pod is loading


### PR DESCRIPTION
Engage or disengage brakes as needed during enter actions for state changes. Resolves #60.