### PR TITLE
Incorporate high-voltage system with FSM 

### DIFF
--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -163,13 +163,13 @@ impl StateMachine {
 
 	fn _enter_load(&mut self) {
 		info!("Entering Load state");
-		self.high_voltage_system.enable(); // Enable high voltage system -- may move later
 		self.brakes.disengage();
 		self.signal_light.disable();
 	}
 
 	fn _enter_running(&mut self) {
 		info!("Entering Running state");
+		self.high_voltage_system.enable(); // Enable high voltage system -- may move later
 		self.signal_light.enable();
 		self.brakes.disengage();
 	}

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 use tracing::info;
 
 use crate::components::brakes::Brakes;
+use crate::components::high_voltage_system::HighVoltageSystem;
 use crate::components::lim_temperature::LimTemperature;
 use crate::components::pressure_transducer::PressureTransducer;
 use crate::components::signal_light::SignalLight;
@@ -43,6 +44,7 @@ pub struct StateMachine {
 	downstream_pressure_transducer: PressureTransducer,
 	lim_temperature_port: LimTemperature,
 	lim_temperature_starboard: LimTemperature,
+	high_voltage_system: HighVoltageSystem,
 }
 
 impl StateMachine {
@@ -96,6 +98,7 @@ impl StateMachine {
 			lim_temperature_starboard: LimTemperature::new(ads1x1x::SlaveAddr::Alternative(
 				false, true,
 			)),
+			high_voltage_system: HighVoltageSystem::new(),
 		}
 	}
 
@@ -160,6 +163,7 @@ impl StateMachine {
 
 	fn _enter_load(&mut self) {
 		info!("Entering Load state");
+		self.high_voltage_system.enable(); // Enable high voltage system -- may move later
 		self.brakes.disengage();
 		self.signal_light.disable();
 	}
@@ -178,9 +182,9 @@ impl StateMachine {
 
 	fn _enter_halted(&mut self) {
 		info!("Entering Halted state");
-		// self.hvs.disable()
 		self.signal_light.disable();
 		self.brakes.engage();
+		self.high_voltage_system.disable();
 	}
 
 	/// Perform operations when the pod is loading


### PR DESCRIPTION
Enable high-voltage system when running the pod; disable when halting or faulting but not when stopping.
Resolves #75.