### PR TITLE
Create inverter board abstraction to send velocity and throttle to Raspberry Pi Pico

### DIFF
--- a/pod-operation/src/components/inverter_board.rs
+++ b/pod-operation/src/components/inverter_board.rs
@@ -1,0 +1,18 @@
+use rppal::uart::{Parity, Uart};
+pub struct InverterBoard {
+	uart: Uart,
+}
+
+impl InverterBoard {
+	pub fn new() -> Self {
+		let uart = Uart::with_path("/dev/ttyACM0", 9600, Parity::None, 8, 1).unwrap();
+		Self { uart }
+	}
+
+	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
+		let vel_str = velocity.to_string();
+		let throttle_str = throttle.to_string();
+		let data = vel_str + " " + &throttle_str + "\n";
+		self.uart.write(data.as_bytes()).unwrap();
+	}
+}

--- a/pod-operation/src/components/inverter_board.rs
+++ b/pod-operation/src/components/inverter_board.rs
@@ -1,18 +1,25 @@
 use rppal::uart::{Parity, Uart};
+
+const SERIAL_PATH: &str = "/dev/tty/ACM0";
+const BAUD_RATE: u32 = 9600;
+const PARITY: Parity = Parity::None;
+const DATA_BITS: u8 = 8;
+const STOP_BITS: u8 = 1;
+
 pub struct InverterBoard {
 	uart: Uart,
 }
 
 impl InverterBoard {
 	pub fn new() -> Self {
-		let uart = Uart::with_path("/dev/ttyACM0", 9600, Parity::None, 8, 1).unwrap();
+		let uart = Uart::with_path(SERIAL_PATH, BAUD_RATE, PARITY, DATA_BITS, STOP_BITS).unwrap();
 		Self { uart }
 	}
 
+	/// Combine velocity and throttle into a space-separated string message and then send it over to
+	/// the Pico as bytes.
 	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
-		let vel_str = velocity.to_string();
-		let throttle_str = throttle.to_string();
-		let data = vel_str + " " + &throttle_str + "\n";
-		self.uart.write(data.as_bytes()).unwrap();
+		let message = format!("{velocity} {throttle}\n");
+		self.uart.write(message.as_bytes()).unwrap();
 	}
 }

--- a/pod-operation/src/components/mod.rs
+++ b/pod-operation/src/components/mod.rs
@@ -1,6 +1,7 @@
 pub mod brakes;
 pub mod gyro;
 pub mod high_voltage_system;
+pub mod inverter_board;
 pub mod lim_current;
 pub mod lim_temperature;
 pub mod pressure_transducer;

--- a/pod-operation/src/demo.rs
+++ b/pod-operation/src/demo.rs
@@ -3,6 +3,7 @@ use tracing::info;
 use crate::components::brakes::Brakes;
 use crate::components::gyro::Gyroscope;
 use crate::components::high_voltage_system::HighVoltageSystem;
+use crate::components::inverter_board::InverterBoard;
 use crate::components::lim_current::LimCurrent;
 use crate::components::lim_temperature::LimTemperature;
 use crate::components::pressure_transducer::PressureTransducer;
@@ -119,5 +120,12 @@ pub async fn high_voltage_system(mut high_voltage_system: HighVoltageSystem) {
 		}
 
 		i += 1;
+	}
+}
+
+pub async fn inverter_control(mut inverter_control: InverterBoard) {
+	loop {
+		inverter_control.send_control(0.0, 1.0);
+		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 	}
 }

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -10,6 +10,7 @@ mod state_machine;
 use crate::components::brakes::Brakes;
 use crate::components::gyro::Gyroscope;
 use crate::components::high_voltage_system::HighVoltageSystem;
+use crate::components::inverter_board::InverterBoard;
 use crate::components::lim_current::LimCurrent;
 use crate::components::lim_temperature::LimTemperature;
 use crate::components::pressure_transducer::PressureTransducer;
@@ -55,6 +56,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let limcurrent = LimCurrent::new(ads1x1x::SlaveAddr::Default);
 	tokio::spawn(demo::read_lim_current(limcurrent));
+
+	let inverter_board = InverterBoard::new();
+	tokio::spawn(demo::inverter_control(inverter_board));
 
 	let app = axum::Router::new().layer(layer);
 


### PR DESCRIPTION
Resolves #35.

## Changes
- Add new `InverterBoard` struct
- Write `send_control` method to send a velocity and throttle to a Raspberry Pi Pico via UART serial communication over `/dev/ttyACM0` (i.e. a USB Type A port on the Raspberry Pi)
- Include demo function that sends a velocity of 0 and a throttle of 1 to a Pico every second

## Testing
1. Plug a Pico into a Raspberry Pi
2. Build `hx9-control/pod-operation` with `cargo build --release`, ensuring that it is being compiled to the `aarch64` (Raspberry Pi) architecture
3. Copy the executable located in `target/aarch64-unknown-linux-gnu/release/pod-operation` to the Raspberry Pi
4. Run the `pod-operation` executable and observe the waveform on the oscilloscope or connect an LED to the pin outputting the waveform and observe it blinking