### PR TITLE
Extract GPIO pin number constants to common enum

### DIFF
--- a/pod-operation/Cargo.lock
+++ b/pod-operation/Cargo.lock
@@ -343,6 +343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +616,16 @@ checksum = "6a93dcf42590b25525d79f7e497f3e8caf909ff8d53a2989b3c8d809980e647e"
 dependencies = [
  "byteorder",
  "embedded-hal 0.2.7",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -821,6 +843,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +941,7 @@ dependencies = [
  "lidar_lite_v3",
  "mpu6050",
  "nb 1.1.0",
+ "num_enum",
  "once_cell",
  "rppal",
  "serde",
@@ -913,6 +957,15 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1368,6 +1421,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,3 +1817,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 enum-map = "2.7.3"
 once_cell = "1.19.0"
+num_enum = "0.7.2"
 
 rppal = { version = "0.17.1", features = ["hal"] }
 ina219 = "0.1.0"

--- a/pod-operation/src/components/brakes.rs
+++ b/pod-operation/src/components/brakes.rs
@@ -12,7 +12,7 @@ impl Brakes {
 		Brakes {
 			pin: Gpio::new()
 				.unwrap()
-				.get(GpioPins::PNEUMATICS_RELAY)
+				.get(GpioPins::PNEUMATICS_RELAY.into())
 				.unwrap()
 				.into_output(),
 		}

--- a/pod-operation/src/components/brakes.rs
+++ b/pod-operation/src/components/brakes.rs
@@ -1,17 +1,20 @@
+use rppal::gpio::{Gpio, OutputPin};
 use tracing::debug;
 
-use rppal::gpio::{Gpio, OutputPin};
+use crate::utils::GpioPins;
 
 pub struct Brakes {
 	pin: OutputPin,
 }
 
-const PIN_BRAKES: u8 = 26;
-
 impl Brakes {
 	pub fn new() -> Self {
 		Brakes {
-			pin: Gpio::new().unwrap().get(PIN_BRAKES).unwrap().into_output(),
+			pin: Gpio::new()
+				.unwrap()
+				.get(GpioPins::PNEUMATICS_RELAY)
+				.unwrap()
+				.into_output(),
 		}
 	}
 

--- a/pod-operation/src/components/high_voltage_system.rs
+++ b/pod-operation/src/components/high_voltage_system.rs
@@ -12,7 +12,7 @@ impl HighVoltageSystem {
 		HighVoltageSystem {
 			pin: Gpio::new()
 				.unwrap()
-				.get(GpioPins::CONTACTOR_RELAY)
+				.get(GpioPins::CONTACTOR_RELAY.into())
 				.unwrap()
 				.into_output(),
 		}

--- a/pod-operation/src/components/high_voltage_system.rs
+++ b/pod-operation/src/components/high_voltage_system.rs
@@ -1,19 +1,18 @@
+use rppal::gpio::{Gpio, OutputPin};
 use tracing::debug;
 
-use rppal::gpio::{Gpio, OutputPin};
+use crate::utils::GpioPins;
 
 pub struct HighVoltageSystem {
 	pin: OutputPin,
 }
-
-const PIN_CONTACTOR_RELAY: u8 = 20;
 
 impl HighVoltageSystem {
 	pub fn new() -> Self {
 		HighVoltageSystem {
 			pin: Gpio::new()
 				.unwrap()
-				.get(PIN_CONTACTOR_RELAY)
+				.get(GpioPins::CONTACTOR_RELAY)
 				.unwrap()
 				.into_output(),
 		}

--- a/pod-operation/src/components/signal_light.rs
+++ b/pod-operation/src/components/signal_light.rs
@@ -1,19 +1,18 @@
+use rppal::gpio::{Gpio, OutputPin};
 use tracing::debug;
 
-use rppal::gpio::{Gpio, OutputPin};
+use crate::utils::GpioPins;
 
 pub struct SignalLight {
 	pin: OutputPin,
 }
-
-const PIN_SIGNAL_LIGHT: u8 = 21;
 
 impl SignalLight {
 	pub fn new() -> Self {
 		SignalLight {
 			pin: Gpio::new()
 				.unwrap()
-				.get(PIN_SIGNAL_LIGHT)
+				.get(GpioPins::SIGNAL_LIGHT_RELAY)
 				.unwrap()
 				.into_output(),
 		}

--- a/pod-operation/src/components/signal_light.rs
+++ b/pod-operation/src/components/signal_light.rs
@@ -12,7 +12,7 @@ impl SignalLight {
 		SignalLight {
 			pin: Gpio::new()
 				.unwrap()
-				.get(GpioPins::SIGNAL_LIGHT_RELAY)
+				.get(GpioPins::SIGNAL_LIGHT_RELAY.into())
 				.unwrap()
 				.into_output(),
 		}

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -1,8 +1,8 @@
-use rppal::gpio::{Gpio, InputPin, Level};
 use std::time::Instant;
 
-const PIN_ENCODER_A: u8 = 1;
-const PIN_ENCODER_B: u8 = 2;
+use rppal::gpio::{Gpio, InputPin, Level};
+
+use crate::utils::GpioPins;
 
 pub struct WheelEncoder {
 	counter: f32,
@@ -20,8 +20,8 @@ impl WheelEncoder {
 		let gpio = Gpio::new().unwrap();
 		WheelEncoder {
 			counter: 0.0,
-			pin_a: gpio.get(PIN_ENCODER_A).unwrap().into_input(),
-			pin_b: gpio.get(PIN_ENCODER_B).unwrap().into_input(),
+			pin_a: gpio.get(GpioPins::WHEEL_ENCODER_A).unwrap().into_input(),
+			pin_b: gpio.get(GpioPins::WHEEL_ENCODER_B).unwrap().into_input(),
 			a_last_read: Level::High,
 			b_last_read: Level::Low,
 			last_distance: 0.0,

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -20,8 +20,14 @@ impl WheelEncoder {
 		let gpio = Gpio::new().unwrap();
 		WheelEncoder {
 			counter: 0.0,
-			pin_a: gpio.get(GpioPins::WHEEL_ENCODER_A).unwrap().into_input(),
-			pin_b: gpio.get(GpioPins::WHEEL_ENCODER_B).unwrap().into_input(),
+			pin_a: gpio
+				.get(GpioPins::WHEEL_ENCODER_A.into())
+				.unwrap()
+				.into_input(),
+			pin_b: gpio
+				.get(GpioPins::WHEEL_ENCODER_B.into())
+				.unwrap()
+				.into_input(),
 			a_last_read: Level::High,
 			b_last_read: Level::Low,
 			last_distance: 0.0,

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::FmtSubscriber;
 mod components;
 mod demo;
 mod state_machine;
+mod utils;
 
 use crate::components::brakes::Brakes;
 use crate::components::gyro::Gyroscope;

--- a/pod-operation/src/utils/gpio.rs
+++ b/pod-operation/src/utils/gpio.rs
@@ -1,13 +1,12 @@
-#[non_exhaustive]
-pub struct GpioPins;
-
-// Not discriminant but removes need to cast
-impl GpioPins {
-	const _RESERVED_I2C_SDA: u8 = 2;
-	const _RESERVED_I2C_SCL: u8 = 3;
-	pub const WHEEL_ENCODER_A: u8 = 23;
-	pub const WHEEL_ENCODER_B: u8 = 24;
-	pub const CONTACTOR_RELAY: u8 = 20;
-	pub const SIGNAL_LIGHT_RELAY: u8 = 21;
-	pub const PNEUMATICS_RELAY: u8 = 26;
+#[derive(num_enum::IntoPrimitive)]
+#[repr(u8)]
+#[allow(non_camel_case_types)]
+pub enum GpioPins {
+	_RESERVED_I2C_SDA = 2,
+	_RESERVED_I2C_SCL = 3,
+	WHEEL_ENCODER_A = 23,
+	WHEEL_ENCODER_B = 24,
+	CONTACTOR_RELAY = 20,
+	SIGNAL_LIGHT_RELAY = 21,
+	PNEUMATICS_RELAY = 26,
 }

--- a/pod-operation/src/utils/gpio.rs
+++ b/pod-operation/src/utils/gpio.rs
@@ -1,0 +1,13 @@
+#[non_exhaustive]
+pub struct GpioPins;
+
+// Not discriminant but removes need to cast
+impl GpioPins {
+	const _RESERVED_I2C_SDA: u8 = 2;
+	const _RESERVED_I2C_SCL: u8 = 3;
+	pub const WHEEL_ENCODER_A: u8 = 23;
+	pub const WHEEL_ENCODER_B: u8 = 24;
+	pub const CONTACTOR_RELAY: u8 = 20;
+	pub const SIGNAL_LIGHT_RELAY: u8 = 21;
+	pub const PNEUMATICS_RELAY: u8 = 26;
+}

--- a/pod-operation/src/utils/mod.rs
+++ b/pod-operation/src/utils/mod.rs
@@ -1,0 +1,2 @@
+mod gpio;
+pub use gpio::GpioPins;


### PR DESCRIPTION
Resolves #84.

## Changes
- Move all constants for GPIO pin numbers used by components to a single module to avoid having conflicting numbers
  - `GpioPins` enum will enforce discriminant
- Use [`num_enum::IntoPrimitive`](https://docs.rs/num_enum/latest/num_enum/derive.IntoPrimitive.html) to convert from enum value to `u8` using `.into()`