### PR TITLE
Flip divider resistance circuit for thermistors

### DIFF
--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -13,7 +13,7 @@ const C_TO_K_CONVERSION: f32 = 273.15;
 // connected to a thermistor, with the ADS1015 is measuring the node connecting
 // the two (a voltage divider circuit).
 
-const DIVIDER_RESISTANCE: f32 = 22000.0; // Ohms
+const DIVIDER_RESISTANCE: f32 = 1000.0; // Ohms
 const V_IN: f32 = 5.0; // Volts
 const BETA: f32 = 3950.0; // Kelvins
 const R_0: f32 = 10000.0; // Ohms

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -45,7 +45,7 @@ impl LimTemperature {
 
 	pub fn read_lim_temps(&mut self) -> (f32, f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
-			.map(|channel| block!(f32::from(self.ads1015.read(channel).unwrap())) / 500.0)
+			.map(|channel| f32::from(block!(self.ads1015.read(channel)).unwrap()) / 500.0)
 			.map(voltage_to_temp)
 			.into()
 	}

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -6,8 +6,6 @@ use ads1x1x::FullScaleRange;
 use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
 use nb::block;
 use rppal::i2c::I2c;
-use std::thread::sleep;
-use std::time::Duration;
 
 const C_TO_K_CONVERSION: f32 = 273.15;
 

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -19,8 +19,7 @@ const BETA: f32 = 3950.0; // Kelvins
 const R_0: f32 = 10000.0; // Ohms
 const ROOM_TEMP: f32 = 25.0 + C_TO_K_CONVERSION; // Kelvins
 
-fn voltage_to_temp(voltage: i16) -> f32 {
-	let voltage = f32::from(voltage) / 500.0;
+fn voltage_to_temp(voltage: f32) -> f32 {
 	let thermistor_resistance = ((V_IN - voltage) * DIVIDER_RESISTANCE) / voltage;
 	let r_inf = R_0 * std::f32::consts::E.powf(-BETA / ROOM_TEMP);
 	let temp_kelvins = BETA / (thermistor_resistance / r_inf).ln();
@@ -46,7 +45,7 @@ impl LimTemperature {
 
 	pub fn read_lim_temps(&mut self) -> (f32, f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
-			.map(|channel| block!(self.ads1015.read(channel)).unwrap())
+			.map(|channel| block!(f32::from(self.ads1015.read(channel)).unwrap()) / 500.0)
 			.map(voltage_to_temp)
 			.into()
 	}

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -2,7 +2,6 @@ use ads1x1x::ic::{Ads1015, Resolution12Bit};
 use ads1x1x::interface::I2cInterface;
 use ads1x1x::mode::OneShot;
 use ads1x1x::ChannelSelection::{SingleA0, SingleA1, SingleA2, SingleA3};
-use ads1x1x::FullScaleRange;
 use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
 use nb::block;
 use rppal::i2c::I2c;
@@ -33,9 +32,7 @@ pub struct LimTemperature {
 impl LimTemperature {
 	pub fn new(device_address: SlaveAddr) -> Self {
 		let i2cdev = I2c::new().unwrap();
-		let mut adc = Ads1x1x::new_ads1015(i2cdev, device_address);
-		adc.set_full_scale_range(FullScaleRange::Within4_096V)
-			.unwrap();
+		let adc = Ads1x1x::new_ads1015(i2cdev, device_address);
 		LimTemperature { ads1015: adc }
 	}
 
@@ -45,7 +42,7 @@ impl LimTemperature {
 
 	pub fn read_lim_temps(&mut self) -> (f32, f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
-			.map(|channel| f32::from(block!(self.ads1015.read(channel)).unwrap()) / 500.0)
+			.map(|channel| f32::from(block!(self.ads1015.read(channel)).unwrap()) / 1000.0)
 			.map(voltage_to_temp)
 			.into()
 	}

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -23,8 +23,7 @@ const ROOM_TEMP: f32 = 25.0 + C_TO_K_CONVERSION; // Kelvins
 
 fn voltage_to_temp(voltage: i16) -> f32 {
 	let voltage = f32::from(voltage) / 500.0;
-
-	let thermistor_resistance = ((V_IN - voltage) * DIVIDER_RESISTANCE) / (voltage);
+	let thermistor_resistance = ((V_IN - voltage) * DIVIDER_RESISTANCE) / voltage;
 	let r_inf = R_0 * std::f32::consts::E.powf(-BETA / ROOM_TEMP);
 	let temp_kelvins = BETA / (thermistor_resistance / r_inf).ln();
 	temp_kelvins - C_TO_K_CONVERSION
@@ -36,7 +35,6 @@ pub struct LimTemperature {
 
 impl LimTemperature {
 	pub fn new(device_address: SlaveAddr) -> Self {
-		sleep(Duration::from_secs(1));
 		let i2cdev = I2c::new().unwrap();
 		let mut adc = Ads1x1x::new_ads1015(i2cdev, device_address);
 		adc.set_full_scale_range(FullScaleRange::Within4_096V)

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -45,7 +45,7 @@ impl LimTemperature {
 
 	pub fn read_lim_temps(&mut self) -> (f32, f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
-			.map(|channel| block!(f32::from(self.ads1015.read(channel)).unwrap()) / 500.0)
+			.map(|channel| block!(f32::from(self.ads1015.read(channel).unwrap())) / 500.0)
 			.map(voltage_to_temp)
 			.into()
 	}


### PR DESCRIPTION
The control board circuit actually has the ADC measure the voltage across the divider resistor rather than across the thermistor. This unfortunately means the ADC reading clips as temperature increases rather than decreases. To stay within the 2.048V FSR, the divider resistance is changed to 1 kΩ.