### PR TITLE
Use 4-element array instead of 4-tuple to represent LIM temperature readings

### DIFF
--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -41,10 +41,9 @@ impl LimTemperature {
 		self.ads1015.destroy_ads1015();
 	}
 
-	pub fn read_lim_temps(&mut self) -> (f32, f32, f32, f32) {
+	pub fn read_lim_temps(&mut self) -> [f32; 4] {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
 			.map(|channel| block!(self.ads1015.read(channel)).unwrap())
 			.map(voltage_to_temp)
-			.into()
 	}
 }

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -219,8 +219,8 @@ impl StateMachine {
 		if self.downstream_pressure_transducer.read_pressure() < MIN_PRESSURE {
 			return State::Faulted;
 		}
-		let default_readings: [f32; 4] = self.lim_temperature_port.read_lim_temps().into();
-		let alternative_readings: [f32; 4] = self.lim_temperature_starboard.read_lim_temps().into();
+		let default_readings = self.lim_temperature_port.read_lim_temps();
+		let alternative_readings = self.lim_temperature_starboard.read_lim_temps();
 		let all_readings = [default_readings, alternative_readings].concat();
 		if all_readings
 			.iter()

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -221,9 +221,9 @@ impl StateMachine {
 		}
 		let default_readings = self.lim_temperature_port.read_lim_temps();
 		let alternative_readings = self.lim_temperature_starboard.read_lim_temps();
-		let all_readings = [default_readings, alternative_readings].concat();
-		if all_readings
+		if default_readings
 			.iter()
+			.chain(alternative_readings.iter())
 			.any(|&reading| reading > LIM_TEMP_THRESHOLD)
 		{
 			return State::Faulted;


### PR DESCRIPTION
Resolves #73.