### PR TITLE
Display state transition messages in `Console`

### DIFF
--- a/control-station/src/components/SensorBoxes/Console.tsx
+++ b/control-station/src/components/SensorBoxes/Console.tsx
@@ -24,7 +24,7 @@ function Console() {
 						ref={index === podData.messages.length - 1 ? listEndRef : null}
 					>
 						{prop.timestamp} &nbsp;
-						{prop.message.toUpperCase()} State
+						{prop.message.toUpperCase()}
 					</li>
 				))}
 			</ul>

--- a/control-station/src/components/SensorBoxes/Console.tsx
+++ b/control-station/src/components/SensorBoxes/Console.tsx
@@ -1,35 +1,30 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef } from "react";
 import "./SensorData.css";
 import PodContext from "@/services/PodContext";
 
 function Console() {
 	const { podData } = useContext(PodContext);
-	const [stateList, setStateList] = useState<string[]>([]);
 	const listEndRef = useRef<HTMLLIElement | null>(null);
-
-	useEffect(() => {
-		if (podData.state) {
-			setStateList((prev) => [...prev, podData.state]);
-		}
-	}, [podData.state]);
 
 	useEffect(() => {
 		if (listEndRef.current) {
 			listEndRef.current.scrollIntoView({ behavior: "smooth" });
 		}
-	}, [stateList]);
+		console.log(podData.messages);
+	}, [podData.messages]);
 
 	return (
 		<div className="console">
 			<h2>Console</h2>
 			<ul className="console-list">
-				{stateList.map((prop, index) => (
+				{podData.messages.map((prop, index) => (
 					<li
 						key={index}
 						className="console-list-item"
-						ref={index === stateList.length - 1 ? listEndRef : null}
+						ref={index === podData.messages.length - 1 ? listEndRef : null}
 					>
-						{prop} State
+						{prop.timestamp} &nbsp;
+						{prop.message.toUpperCase()} State
 					</li>
 				))}
 			</ul>

--- a/control-station/src/components/SensorBoxes/Console.tsx
+++ b/control-station/src/components/SensorBoxes/Console.tsx
@@ -23,7 +23,7 @@ function Console() {
 						className="console-list-item"
 						ref={index === podData.messages.length - 1 ? listEndRef : null}
 					>
-						{prop.timestamp} &nbsp;
+						{prop.timestamp.toLocaleTimeString("en-US", { hour12: false })} &nbsp;
 						{prop.message.toUpperCase()}
 					</li>
 				))}

--- a/control-station/src/components/SensorBoxes/Console.tsx
+++ b/control-station/src/components/SensorBoxes/Console.tsx
@@ -1,10 +1,26 @@
+import { useContext, useEffect, useState } from "react";
 import "./SensorData.css";
+import PodContext from "@/services/PodContext";
 
 function Console() {
+	const { podData } = useContext(PodContext);
+	const [stateList, setStateList] = useState<string[]>([]);
+
+	useEffect(() => {
+		if (podData.state) {
+			setStateList((prev) => [...prev, podData.state]);
+		}
+	}, [podData.state]);
+
 	return (
 		<div className="console">
 			<h2>Console</h2>
 			<ul className="console-list">
+				{stateList.map((prop, index) => (
+					<li key={index} className="console-list-item">
+						{prop} State
+					</li>
+				))}
 				<li className="console-list-item">Start Sent</li>
 				<li className="console-list-item">Stop Sent</li>
 				<li className="console-list-item">Load Sent</li>

--- a/control-station/src/components/SensorBoxes/Console.tsx
+++ b/control-station/src/components/SensorBoxes/Console.tsx
@@ -1,10 +1,11 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import "./SensorData.css";
 import PodContext from "@/services/PodContext";
 
 function Console() {
 	const { podData } = useContext(PodContext);
 	const [stateList, setStateList] = useState<string[]>([]);
+	const listEndRef = useRef<HTMLLIElement | null>(null);
 
 	useEffect(() => {
 		if (podData.state) {
@@ -12,19 +13,25 @@ function Console() {
 		}
 	}, [podData.state]);
 
+	useEffect(() => {
+		if (listEndRef.current) {
+			listEndRef.current.scrollIntoView({ behavior: "smooth" });
+		}
+	}, [stateList]);
+
 	return (
 		<div className="console">
 			<h2>Console</h2>
 			<ul className="console-list">
 				{stateList.map((prop, index) => (
-					<li key={index} className="console-list-item">
+					<li
+						key={index}
+						className="console-list-item"
+						ref={index === stateList.length - 1 ? listEndRef : null}
+					>
 						{prop} State
 					</li>
 				))}
-				<li className="console-list-item">Start Sent</li>
-				<li className="console-list-item">Stop Sent</li>
-				<li className="console-list-item">Load Sent</li>
-				<li className="console-list-item">Force Stop Sent</li>
 			</ul>
 		</div>
 	);

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -136,7 +136,7 @@ class PodSocketClient {
 		this.setPodData((d) => ({
 			...d,
 			state: newState,
-			messages: d.messages ? [...d.messages, newMessage] : [newMessage],
+			messages: [...d.messages, newMessage],
 		}));
 	}
 }

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -125,8 +125,8 @@ class PodSocketClient {
 		const currentTime = new Date();
 		const timestamp = currentTime.toLocaleTimeString("en-US", { hour12: false });
 
-		const newMessage: Message = {
-			timestamp: timestamp,
+		const newMessage = {
+			timestamp,
 			message: response,
 		};
 

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -19,7 +19,7 @@ interface ServerToClientEvents {
 }
 
 interface Message {
-	timestamp: string;
+	timestamp: Date;
 	message: string;
 }
 
@@ -122,9 +122,7 @@ class PodSocketClient {
 	}
 
 	private addMessage(response: string, newState: State): void {
-		const currentTime = new Date();
-		const timestamp = currentTime.toLocaleTimeString("en-US", { hour12: false });
-
+		const timestamp = new Date();
 		const newMessage = {
 			timestamp,
 			message: response,

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -18,6 +18,11 @@ interface ServerToClientEvents {
 	serverResponse: (data: string) => void;
 }
 
+interface Message {
+	timestamp: string;
+	message: string;
+}
+
 interface ClientToServerEvents {
 	load: (ack: (data: string) => void) => void;
 	run: (ack: (data: string) => void) => void;
@@ -28,6 +33,7 @@ interface ClientToServerEvents {
 export interface PodData {
 	connected: boolean;
 	state: State;
+	messages: Message[];
 }
 
 type SetPodData = Dispatch<SetStateAction<PodData>>;
@@ -74,28 +80,28 @@ class PodSocketClient {
 	sendLoad(): void {
 		this.socket.emit("load", (response: string) => {
 			console.log("Server acknowledged:", response);
-			this.setPodData((d) => ({ ...d, state: State.Load }));
+			this.addMessage(response, State.Load);
 		});
 	}
 
 	sendRun(): void {
 		this.socket.emit("run", (response: string) => {
 			console.log("Server acknowledged:", response);
-			this.setPodData((d) => ({ ...d, state: State.Running }));
+			this.addMessage(response, State.Running);
 		});
 	}
 
 	sendStop(): void {
 		this.socket.emit("stop", (response: string) => {
 			console.log("Server acknowledged:", response);
-			this.setPodData((d) => ({ ...d, state: State.Stopped }));
+			this.addMessage(response, State.Stopped);
 		});
 	}
 
 	sendHalt(): void {
 		this.socket.emit("halt", (response: string) => {
 			console.log("Server acknowledged:", response);
-			this.setPodData((d) => ({ ...d, state: State.Halted }));
+			this.addMessage(response, State.Halted);
 		});
 	}
 
@@ -113,6 +119,25 @@ class PodSocketClient {
 
 	private onData(data: string): void {
 		console.log("server says", data);
+	}
+
+	private addMessage(response: string, newState: State): void {
+		const currentTime = new Date();
+		const hours = currentTime.getHours().toString().padStart(2, "0");
+		const minutes = currentTime.getMinutes().toString().padStart(2, "0");
+		const seconds = currentTime.getSeconds().toString().padStart(2, "0");
+		const timestamp = `${hours}:${minutes}:${seconds}`;
+
+		const newMessage: Message = {
+			timestamp: timestamp,
+			message: response,
+		};
+
+		this.setPodData((d) => ({
+			...d,
+			state: newState,
+			messages: d.messages ? [...d.messages, newMessage] : [newMessage],
+		}));
 	}
 }
 

--- a/control-station/src/services/PodSocketClient.ts
+++ b/control-station/src/services/PodSocketClient.ts
@@ -123,10 +123,7 @@ class PodSocketClient {
 
 	private addMessage(response: string, newState: State): void {
 		const currentTime = new Date();
-		const hours = currentTime.getHours().toString().padStart(2, "0");
-		const minutes = currentTime.getMinutes().toString().padStart(2, "0");
-		const seconds = currentTime.getSeconds().toString().padStart(2, "0");
-		const timestamp = `${hours}:${minutes}:${seconds}`;
+		const timestamp = currentTime.toLocaleTimeString("en-US", { hour12: false });
 
 		const newMessage: Message = {
 			timestamp: timestamp,

--- a/control-station/src/services/usePodData.tsx
+++ b/control-station/src/services/usePodData.tsx
@@ -5,6 +5,7 @@ function usePodData() {
 	const [podData, setPodData] = useState<PodData>({
 		state: State.Disconnected,
 		connected: false,
+		messages: [],
 	});
 
 	const podSocketClient = useMemo(() => new PodSocketClient(setPodData), []);

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -54,16 +54,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let lidar = Lidar::new();
 	tokio::spawn(demo::read_lidar(lidar));
 
-	let mut state_machine = StateMachine::new(io);
-	tokio::spawn(async move {
-		state_machine.run().await;
-	});
-
 	let limcurrent = LimCurrent::new(ads1x1x::SlaveAddr::Default);
 	tokio::spawn(demo::read_lim_current(limcurrent));
 
 	let inverter_board = InverterBoard::new();
 	tokio::spawn(demo::inverter_control(inverter_board));
+
+	let mut state_machine = StateMachine::new(io);
+	tokio::spawn(async move {
+		state_machine.run().await;
+	});
 
 	let app = axum::Router::new().layer(layer);
 

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -26,39 +26,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let (layer, io) = SocketIo::new_layer();
 
-	// let signal_light = SignalLight::new();
-	// tokio::spawn(demo::blink(signal_light));
+	let signal_light = SignalLight::new();
+	tokio::spawn(demo::blink(signal_light));
 
-	// let upstream_pressure_transducer = PressureTransducer::upstream();
-	// tokio::spawn(demo::read_pressure_transducer(upstream_pressure_transducer));
+	let upstream_pressure_transducer = PressureTransducer::upstream();
+	tokio::spawn(demo::read_pressure_transducer(upstream_pressure_transducer));
 
-	// let downstream_pressure_transducer = PressureTransducer::downstream();
-	// tokio::spawn(demo::read_pressure_transducer(
-	// 	downstream_pressure_transducer,
-	// ));
+	let downstream_pressure_transducer = PressureTransducer::downstream();
+	tokio::spawn(demo::read_pressure_transducer(
+		downstream_pressure_transducer,
+	));
 
-	// let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
-	// tokio::spawn(demo::read_ads1015(ads1015));
+	let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
+	tokio::spawn(demo::read_ads1015(ads1015));
 
-	// let wheel_encoder = WheelEncoder::new();
-	// tokio::spawn(demo::read_wheel_encoder(wheel_encoder));
+	let wheel_encoder = WheelEncoder::new();
+	tokio::spawn(demo::read_wheel_encoder(wheel_encoder));
 
-	// let gyro: Gyroscope = Gyroscope::new();
-	// tokio::spawn(demo::read_gyroscope(gyro));
-	// let brakes = Brakes::new();
-	// tokio::spawn(demo::brake(brakes));
+	let gyro: Gyroscope = Gyroscope::new();
+	tokio::spawn(demo::read_gyroscope(gyro));
+	let brakes = Brakes::new();
+	tokio::spawn(demo::brake(brakes));
 
-	// let high_voltage_system = HighVoltageSystem::new();
-	// tokio::spawn(demo::high_voltage_system(high_voltage_system));
+	let high_voltage_system = HighVoltageSystem::new();
+	tokio::spawn(demo::high_voltage_system(high_voltage_system));
 
-	// let lidar = Lidar::new();
-	// tokio::spawn(demo::read_lidar(lidar));
+	let lidar = Lidar::new();
+	tokio::spawn(demo::read_lidar(lidar));
 
-	// let limcurrent = LimCurrent::new(ads1x1x::SlaveAddr::Default);
-	// tokio::spawn(demo::read_lim_current(limcurrent));
+	let limcurrent = LimCurrent::new(ads1x1x::SlaveAddr::Default);
+	tokio::spawn(demo::read_lim_current(limcurrent));
 
-	// let inverter_board = InverterBoard::new();
-	// tokio::spawn(demo::inverter_control(inverter_board));
+	let inverter_board = InverterBoard::new();
+	tokio::spawn(demo::inverter_control(inverter_board));
 
 	let mut state_machine = StateMachine::new(io);
 	tokio::spawn(async move {

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -26,39 +26,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let (layer, io) = SocketIo::new_layer();
 
-	let signal_light = SignalLight::new();
-	tokio::spawn(demo::blink(signal_light));
+	// let signal_light = SignalLight::new();
+	// tokio::spawn(demo::blink(signal_light));
 
-	let upstream_pressure_transducer = PressureTransducer::upstream();
-	tokio::spawn(demo::read_pressure_transducer(upstream_pressure_transducer));
+	// let upstream_pressure_transducer = PressureTransducer::upstream();
+	// tokio::spawn(demo::read_pressure_transducer(upstream_pressure_transducer));
 
-	let downstream_pressure_transducer = PressureTransducer::downstream();
-	tokio::spawn(demo::read_pressure_transducer(
-		downstream_pressure_transducer,
-	));
+	// let downstream_pressure_transducer = PressureTransducer::downstream();
+	// tokio::spawn(demo::read_pressure_transducer(
+	// 	downstream_pressure_transducer,
+	// ));
 
-	let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
-	tokio::spawn(demo::read_ads1015(ads1015));
+	// let ads1015 = LimTemperature::new(ads1x1x::SlaveAddr::Default);
+	// tokio::spawn(demo::read_ads1015(ads1015));
 
-	let wheel_encoder = WheelEncoder::new();
-	tokio::spawn(demo::read_wheel_encoder(wheel_encoder));
+	// let wheel_encoder = WheelEncoder::new();
+	// tokio::spawn(demo::read_wheel_encoder(wheel_encoder));
 
-	let gyro: Gyroscope = Gyroscope::new();
-	tokio::spawn(demo::read_gyroscope(gyro));
-	let brakes = Brakes::new();
-	tokio::spawn(demo::brake(brakes));
+	// let gyro: Gyroscope = Gyroscope::new();
+	// tokio::spawn(demo::read_gyroscope(gyro));
+	// let brakes = Brakes::new();
+	// tokio::spawn(demo::brake(brakes));
 
-	let high_voltage_system = HighVoltageSystem::new();
-	tokio::spawn(demo::high_voltage_system(high_voltage_system));
+	// let high_voltage_system = HighVoltageSystem::new();
+	// tokio::spawn(demo::high_voltage_system(high_voltage_system));
 
-	let lidar = Lidar::new();
-	tokio::spawn(demo::read_lidar(lidar));
+	// let lidar = Lidar::new();
+	// tokio::spawn(demo::read_lidar(lidar));
 
-	let limcurrent = LimCurrent::new(ads1x1x::SlaveAddr::Default);
-	tokio::spawn(demo::read_lim_current(limcurrent));
+	// let limcurrent = LimCurrent::new(ads1x1x::SlaveAddr::Default);
+	// tokio::spawn(demo::read_lim_current(limcurrent));
 
-	let inverter_board = InverterBoard::new();
-	tokio::spawn(demo::inverter_control(inverter_board));
+	// let inverter_board = InverterBoard::new();
+	// tokio::spawn(demo::inverter_control(inverter_board));
 
 	let mut state_machine = StateMachine::new(io);
 	tokio::spawn(async move {

--- a/pod-operation/src/state_machine.rs
+++ b/pod-operation/src/state_machine.rs
@@ -39,15 +39,15 @@ pub struct StateMachine {
 	enter_actions: EnumMap<State, fn(&mut Self)>,
 	state_transitions: EnumMap<State, Option<StateTransition>>,
 	io: SocketIo,
-	brakes: Brakes,
-	signal_light: SignalLight,
-	wheel_encoder: WheelEncoder,
-	//upstream_pressure_transducer: PressureTransducer,
-	downstream_pressure_transducer: PressureTransducer,
-	lim_temperature_port: LimTemperature,
-	lim_temperature_starboard: LimTemperature,
-	high_voltage_system: HighVoltageSystem,
-	lidar: Lidar,
+	// brakes: Brakes,
+	// signal_light: SignalLight,
+	// wheel_encoder: WheelEncoder,
+	// //upstream_pressure_transducer: PressureTransducer,
+	// downstream_pressure_transducer: PressureTransducer,
+	// lim_temperature_port: LimTemperature,
+	// lim_temperature_starboard: LimTemperature,
+	// high_voltage_system: HighVoltageSystem,
+	// lidar: Lidar,
 }
 
 impl StateMachine {
@@ -94,17 +94,17 @@ impl StateMachine {
 			enter_actions,
 			state_transitions,
 			io,
-			brakes: Brakes::new(),
-			signal_light: SignalLight::new(),
-			wheel_encoder: WheelEncoder::new(),
-			//upstream_pressure_transducer: PressureTransducer::upstream(),
-			downstream_pressure_transducer: PressureTransducer::downstream(),
-			lim_temperature_port: LimTemperature::new(ads1x1x::SlaveAddr::Default),
-			lim_temperature_starboard: LimTemperature::new(ads1x1x::SlaveAddr::Alternative(
-				false, true,
-			)),
-			high_voltage_system: HighVoltageSystem::new(),
-			lidar: Lidar::new(),
+			// brakes: Brakes::new(),
+			// signal_light: SignalLight::new(),
+			// wheel_encoder: WheelEncoder::new(),
+			// //upstream_pressure_transducer: PressureTransducer::upstream(),
+			// downstream_pressure_transducer: PressureTransducer::downstream(),
+			// lim_temperature_port: LimTemperature::new(ads1x1x::SlaveAddr::Default),
+			// lim_temperature_starboard: LimTemperature::new(ads1x1x::SlaveAddr::Alternative(
+			// 	false, true,
+			// )),
+			// high_voltage_system: HighVoltageSystem::new(),
+			// lidar: Lidar::new(),
 		}
 	}
 
@@ -164,33 +164,33 @@ impl StateMachine {
 
 	fn _enter_init(&mut self) {
 		info!("Entering Init state");
-		self.signal_light.disable();
+		// self.signal_light.disable();
 	}
 
 	fn _enter_load(&mut self) {
 		info!("Entering Load state");
-		self.brakes.disengage();
-		self.signal_light.disable();
+		// self.brakes.disengage();
+		// self.signal_light.disable();
 	}
 
 	fn _enter_running(&mut self) {
 		info!("Entering Running state");
-		self.high_voltage_system.enable(); // Enable high voltage system -- may move later
-		self.signal_light.enable();
-		self.brakes.disengage();
+		// self.high_voltage_system.enable(); // Enable high voltage system -- may move later
+		// self.signal_light.enable();
+		// self.brakes.disengage();
 	}
 
 	fn _enter_stopped(&mut self) {
 		info!("Entering Stopped state");
-		self.signal_light.disable();
-		self.brakes.engage();
+		// self.signal_light.disable();
+		// self.brakes.engage();
 	}
 
 	fn _enter_halted(&mut self) {
 		info!("Entering Halted state");
-		self.signal_light.disable();
-		self.brakes.engage();
-		self.high_voltage_system.disable();
+		// self.signal_light.disable();
+		// self.brakes.engage();
+		// self.high_voltage_system.disable();
 	}
 
 	fn _enter_faulted(&mut self) {
@@ -200,9 +200,9 @@ impl StateMachine {
 			.unwrap()
 			.emit("fault", "123")
 			.ok();
-		self.signal_light.disable();
-		self.brakes.engage();
-		self.high_voltage_system.disable();
+		// self.signal_light.disable();
+		// self.brakes.engage();
+		// self.high_voltage_system.disable();
 	}
 
 	/// Perform operations when the pod is loading
@@ -215,27 +215,27 @@ impl StateMachine {
 	/// Perform operations when the pod is running
 	fn _running_periodic(&mut self) -> State {
 		info!("Rolling Running state");
-		let encoder_value = self.wheel_encoder.measure().expect("wheel encoder faulted"); // Read the encoder value
-		if encoder_value > STOP_THRESHOLD {
-			return State::Stopped;
-		}
+		// let encoder_value = self.wheel_encoder.measure().expect("wheel encoder faulted"); // Read the encoder value
+		// if encoder_value > STOP_THRESHOLD {
+		// 	return State::Stopped;
+		// }
 
-		if self.downstream_pressure_transducer.read_pressure() < MIN_PRESSURE {
-			return State::Faulted;
-		}
-		let default_readings = self.lim_temperature_port.read_lim_temps();
-		let alternative_readings = self.lim_temperature_starboard.read_lim_temps();
-		if default_readings
-			.iter()
-			.chain(alternative_readings.iter())
-			.any(|&reading| reading > LIM_TEMP_THRESHOLD)
-		{
-			return State::Faulted;
-		}
-		// Last 20% of the track, as indicated by braking
-		if self.lidar.read_distance() < END_OF_TRACK {
-			return State::Faulted;
-		}
+		// if self.downstream_pressure_transducer.read_pressure() < MIN_PRESSURE {
+		// 	return State::Faulted;
+		// }
+		// let default_readings = self.lim_temperature_port.read_lim_temps();
+		// let alternative_readings = self.lim_temperature_starboard.read_lim_temps();
+		// if default_readings
+		// 	.iter()
+		// 	.chain(alternative_readings.iter())
+		// 	.any(|&reading| reading > LIM_TEMP_THRESHOLD)
+		// {
+		// 	return State::Faulted;
+		// }
+		// // Last 20% of the track, as indicated by braking
+		// if self.lidar.read_distance() < END_OF_TRACK {
+		// 	return State::Faulted;
+		// }
 
 		State::Running
 	}


### PR DESCRIPTION
Store `messages` in `PodData` to display in `Console`.
Resolves #56.