### PR TITLE
Implement feature flags for conditional compilation

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -96,4 +96,4 @@ jobs:
         run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-linux-gnu-gcc\"
 
       - name: Build Pod Operation Program (release)
-        run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-linux-gnu-gcc\" --release
+        run: cargo brpi --config target.$TARGET.linker=\"aarch64-linux-gnu-gcc\"

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -89,8 +89,11 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
-      - name: Lint pod operation
+      - name: Lint pod operation (w/o rpi)
         run: cargo clippy -- -D warnings
+
+      - name: Lint pod operation (w/ rpi)
+        run: cargo clippy --features rpi -- -D warnings
 
       - name: Build Pod Operation Program (debug)
         run: cargo build --target $TARGET --config target.$TARGET.linker=\"aarch64-linux-gnu-gcc\"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"rust-analyzer.cargo.features": [
+		// "rpi"
+	]
+}

--- a/pod-operation/.cargo/config.toml
+++ b/pod-operation/.cargo/config.toml
@@ -1,6 +1,9 @@
 # Configuration to cross-compile for Raspberry Pi
 # Uncomment lines as needed
 
+[alias]
+brpi = "build --release --features rpi --target=aarch64-unknown-linux-gnu"
+
 [build]
 # target = "aarch64-unknown-linux-gnu"
 

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -16,8 +16,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 enum-map = "2.7.3"
 once_cell = "1.19.0"
 num_enum = "0.7.2"
-
-rppal = { version = "0.18.0", features = ["hal"] }
+rppal = { version = "0.18.0", features = ["hal"], optional = true }
 ina219 = "0.1.0"
 ads1x1x = "0.2.2"
 nb = "1.1.0"
@@ -25,3 +24,6 @@ mpu6050 = "0.1.6"
 lidar_lite_v3 = "0.1.0"
 i2cdev = "0.3.1"
 byteorder = "1.4.3"
+
+[features]
+rpi = ["dep:rppal"]

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -26,4 +26,10 @@ i2cdev = "0.3.1"
 byteorder = "1.4.3"
 
 [features]
-rpi = ["dep:rppal", "dep:lidar_lite_v3"]
+gpio = ["dep:rppal"]
+ina219 = ["dep:rppal"]
+ads1015 = ["dep:rppal"]
+mpu6050 = ["dep:rppal"]
+inverter = ["dep:rppal"]
+lidar = ["dep:lidar_lite_v3"]
+rpi = ["gpio", "ads1015", "ina219", "mpu6050", "inverter", "lidar"]

--- a/pod-operation/Cargo.toml
+++ b/pod-operation/Cargo.toml
@@ -21,9 +21,9 @@ ina219 = "0.1.0"
 ads1x1x = "0.2.2"
 nb = "1.1.0"
 mpu6050 = "0.1.6"
-lidar_lite_v3 = "0.1.0"
+lidar_lite_v3 = { version = "0.1.0", optional = true }
 i2cdev = "0.3.1"
 byteorder = "1.4.3"
 
 [features]
-rpi = ["dep:rppal"]
+rpi = ["dep:rppal", "dep:lidar_lite_v3"]

--- a/pod-operation/README.md
+++ b/pod-operation/README.md
@@ -90,10 +90,10 @@ cargo watch -x run
 
 Uncomment the aarch64 Linux linker for your operating system in `.cargo/config.toml`.
 
-To build for production, use the `--release` option:
+To do a release build for the Raspberry Pi, use the `brpi` alias:
 
 ```shell
-cargo build --target aarch64-unknown-linux-gnu --release
+cargo brpi
 ```
 
 Alternatively, use `cross` to compile in a container:

--- a/pod-operation/package.json
+++ b/pod-operation/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "This Rust package is for the main program to be run on the pod. The program runs a finite-state machine to operate the pod components and acts as a Socket.IO server to communicate with the control station.",
 	"scripts": {
-		"lint": "cargo clippy",
+		"lint": "cargo clippy && cargo clippy --features rpi",
 		"format": "cargo fmt",
 		"test": "cargo test"
 	},

--- a/pod-operation/src/components/brakes.rs
+++ b/pod-operation/src/components/brakes.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "rpi"))]
+use crate::utils::mock::OutputPin;
+#[cfg(feature = "rpi")]
 use rppal::gpio::{Gpio, OutputPin};
+
 use tracing::debug;
 
 use crate::utils::GpioPins;
@@ -10,6 +14,11 @@ pub struct Brakes {
 impl Brakes {
 	pub fn new() -> Self {
 		Brakes {
+			#[cfg(not(feature = "rpi"))]
+			pin: OutputPin {
+				pin: GpioPins::PNEUMATICS_RELAY.into(),
+			},
+			#[cfg(feature = "rpi")]
 			pin: Gpio::new()
 				.unwrap()
 				.get(GpioPins::PNEUMATICS_RELAY.into())

--- a/pod-operation/src/components/brakes.rs
+++ b/pod-operation/src/components/brakes.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "gpio"))]
-use crate::utils::mock::OutputPin;
+use crate::utils::mock::gpio::OutputPin;
 #[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, OutputPin};
 

--- a/pod-operation/src/components/brakes.rs
+++ b/pod-operation/src/components/brakes.rs
@@ -1,6 +1,6 @@
-#[cfg(not(feature = "rpi"))]
+#[cfg(not(feature = "gpio"))]
 use crate::utils::mock::OutputPin;
-#[cfg(feature = "rpi")]
+#[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, OutputPin};
 
 use tracing::debug;
@@ -14,11 +14,11 @@ pub struct Brakes {
 impl Brakes {
 	pub fn new() -> Self {
 		Brakes {
-			#[cfg(not(feature = "rpi"))]
+			#[cfg(not(feature = "gpio"))]
 			pin: OutputPin {
 				pin: GpioPins::PNEUMATICS_RELAY.into(),
 			},
-			#[cfg(feature = "rpi")]
+			#[cfg(feature = "gpio")]
 			pin: Gpio::new()
 				.unwrap()
 				.get(GpioPins::PNEUMATICS_RELAY.into())

--- a/pod-operation/src/components/gyro.rs
+++ b/pod-operation/src/components/gyro.rs
@@ -1,11 +1,11 @@
 use mpu6050::Mpu6050;
-#[cfg(feature = "rpi")]
+#[cfg(feature = "mpu6050")]
 use rppal::{hal::Delay, i2c::I2c};
 
 use serde::Serialize;
 
 pub struct Gyroscope {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "mpu6050")]
 	mpu6050: Mpu6050<I2c>,
 }
 
@@ -16,7 +16,7 @@ pub struct Orientation {
 }
 
 impl Gyroscope {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "mpu6050")]
 	pub fn new() -> Self {
 		let i2c = I2c::new().unwrap();
 		let mut mpu6050 = Mpu6050::new(i2c);
@@ -24,7 +24,7 @@ impl Gyroscope {
 		Gyroscope { mpu6050 }
 	}
 
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "mpu6050")]
 	pub fn read_orientation(&mut self) -> Orientation {
 		let angles = self.mpu6050.get_acc_angles().unwrap();
 		Orientation {
@@ -33,12 +33,12 @@ impl Gyroscope {
 		}
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "mpu6050"))]
 	pub fn new() -> Self {
 		Gyroscope {}
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "mpu6050"))]
 	pub fn read_orientation(&mut self) -> Orientation {
 		Orientation {
 			pitch: 0.0,

--- a/pod-operation/src/components/gyro.rs
+++ b/pod-operation/src/components/gyro.rs
@@ -1,9 +1,11 @@
 use mpu6050::Mpu6050;
-use rppal::hal::Delay;
-use rppal::i2c::I2c;
+#[cfg(feature = "rpi")]
+use rppal::{hal::Delay, i2c::I2c};
+
 use serde::Serialize;
 
 pub struct Gyroscope {
+	#[cfg(feature = "rpi")]
 	mpu6050: Mpu6050<I2c>,
 }
 
@@ -14,6 +16,7 @@ pub struct Orientation {
 }
 
 impl Gyroscope {
+	#[cfg(feature = "rpi")]
 	pub fn new() -> Self {
 		let i2c = I2c::new().unwrap();
 		let mut mpu6050 = Mpu6050::new(i2c);
@@ -21,11 +24,25 @@ impl Gyroscope {
 		Gyroscope { mpu6050 }
 	}
 
+	#[cfg(feature = "rpi")]
 	pub fn read_orientation(&mut self) -> Orientation {
 		let angles = self.mpu6050.get_acc_angles().unwrap();
 		Orientation {
 			pitch: angles[1],
 			roll: angles[0],
+		}
+	}
+
+	#[cfg(not(feature = "rpi"))]
+	pub fn new() -> Self {
+		Gyroscope {}
+	}
+
+	#[cfg(not(feature = "rpi"))]
+	pub fn read_orientation(&mut self) -> Orientation {
+		Orientation {
+			pitch: 0.0,
+			roll: 0.0,
 		}
 	}
 }

--- a/pod-operation/src/components/gyro.rs
+++ b/pod-operation/src/components/gyro.rs
@@ -1,6 +1,8 @@
-use mpu6050::Mpu6050;
 #[cfg(feature = "mpu6050")]
-use rppal::{hal::Delay, i2c::I2c};
+use {
+	mpu6050::Mpu6050,
+	rppal::{hal::Delay, i2c::I2c},
+};
 
 use serde::Serialize;
 

--- a/pod-operation/src/components/high_voltage_system.rs
+++ b/pod-operation/src/components/high_voltage_system.rs
@@ -1,6 +1,6 @@
-#[cfg(not(feature = "rpi"))]
+#[cfg(not(feature = "gpio"))]
 use crate::utils::mock::OutputPin;
-#[cfg(feature = "rpi")]
+#[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, OutputPin};
 
 use tracing::debug;
@@ -14,11 +14,11 @@ pub struct HighVoltageSystem {
 impl HighVoltageSystem {
 	pub fn new() -> Self {
 		HighVoltageSystem {
-			#[cfg(not(feature = "rpi"))]
+			#[cfg(not(feature = "gpio"))]
 			pin: OutputPin {
 				pin: GpioPins::CONTACTOR_RELAY.into(),
 			},
-			#[cfg(feature = "rpi")]
+			#[cfg(feature = "gpio")]
 			pin: Gpio::new()
 				.unwrap()
 				.get(GpioPins::CONTACTOR_RELAY.into())

--- a/pod-operation/src/components/high_voltage_system.rs
+++ b/pod-operation/src/components/high_voltage_system.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "gpio"))]
-use crate::utils::mock::OutputPin;
+use crate::utils::mock::gpio::OutputPin;
 #[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, OutputPin};
 

--- a/pod-operation/src/components/high_voltage_system.rs
+++ b/pod-operation/src/components/high_voltage_system.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "rpi"))]
+use crate::utils::mock::OutputPin;
+#[cfg(feature = "rpi")]
 use rppal::gpio::{Gpio, OutputPin};
+
 use tracing::debug;
 
 use crate::utils::GpioPins;
@@ -10,6 +14,11 @@ pub struct HighVoltageSystem {
 impl HighVoltageSystem {
 	pub fn new() -> Self {
 		HighVoltageSystem {
+			#[cfg(not(feature = "rpi"))]
+			pin: OutputPin {
+				pin: GpioPins::CONTACTOR_RELAY.into(),
+			},
+			#[cfg(feature = "rpi")]
 			pin: Gpio::new()
 				.unwrap()
 				.get(GpioPins::CONTACTOR_RELAY.into())

--- a/pod-operation/src/components/inverter_board.rs
+++ b/pod-operation/src/components/inverter_board.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "rpi")]
+#[cfg(feature = "inverter")]
 use rppal::uart::{Parity, Uart};
 
 use tracing::info;
 
-#[cfg(feature = "rpi")]
+#[cfg(feature = "inverter")]
 mod serial_constants {
 	use super::Parity;
 	pub const SERIAL_PATH: &str = "/dev/ttyACM0";
@@ -14,12 +14,12 @@ mod serial_constants {
 }
 
 pub struct InverterBoard {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "inverter")]
 	uart: Uart,
 }
 
 impl InverterBoard {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "inverter")]
 	pub fn new() -> Self {
 		use serial_constants::*;
 		let uart = Uart::with_path(SERIAL_PATH, BAUD_RATE, PARITY, DATA_BITS, STOP_BITS).unwrap();
@@ -28,19 +28,19 @@ impl InverterBoard {
 
 	/// Combine velocity and throttle into a space-separated string message and then send it over to
 	/// the Pico as bytes.
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "inverter")]
 	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
 		let message = format!("{velocity} {throttle}\n");
 		self.uart.write(message.as_bytes()).unwrap();
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "inverter"))]
 	pub fn new() -> Self {
 		InverterBoard {}
 	}
 
 	/// Combine velocity and throttle into a space-separated string message
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "inverter"))]
 	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
 		info!(
 			"Mocking inverter sending message: {} {}",

--- a/pod-operation/src/components/inverter_board.rs
+++ b/pod-operation/src/components/inverter_board.rs
@@ -1,25 +1,50 @@
+#[cfg(feature = "rpi")]
 use rppal::uart::{Parity, Uart};
 
-const SERIAL_PATH: &str = "/dev/tty/ACM0";
-const BAUD_RATE: u32 = 9600;
-const PARITY: Parity = Parity::None;
-const DATA_BITS: u8 = 8;
-const STOP_BITS: u8 = 1;
+use tracing::info;
+
+#[cfg(feature = "rpi")]
+mod serial_constants {
+	use super::Parity;
+	pub const SERIAL_PATH: &str = "/dev/ttyACM0";
+	pub const BAUD_RATE: u32 = 9600;
+	pub const PARITY: Parity = Parity::None;
+	pub const DATA_BITS: u8 = 8;
+	pub const STOP_BITS: u8 = 1;
+}
 
 pub struct InverterBoard {
+	#[cfg(feature = "rpi")]
 	uart: Uart,
 }
 
 impl InverterBoard {
+	#[cfg(feature = "rpi")]
 	pub fn new() -> Self {
+		use serial_constants::*;
 		let uart = Uart::with_path(SERIAL_PATH, BAUD_RATE, PARITY, DATA_BITS, STOP_BITS).unwrap();
 		Self { uart }
 	}
 
 	/// Combine velocity and throttle into a space-separated string message and then send it over to
 	/// the Pico as bytes.
+	#[cfg(feature = "rpi")]
 	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
 		let message = format!("{velocity} {throttle}\n");
 		self.uart.write(message.as_bytes()).unwrap();
+	}
+
+	#[cfg(not(feature = "rpi"))]
+	pub fn new() -> Self {
+		InverterBoard {}
+	}
+
+	/// Combine velocity and throttle into a space-separated string message
+	#[cfg(not(feature = "rpi"))]
+	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
+		info!(
+			"Mocking inverter sending message: {} {}",
+			velocity, throttle
+		);
 	}
 }

--- a/pod-operation/src/components/inverter_board.rs
+++ b/pod-operation/src/components/inverter_board.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "inverter")]
 use rppal::uart::{Parity, Uart};
 
-use tracing::info;
+use tracing::debug;
 
 #[cfg(feature = "inverter")]
 mod serial_constants {
@@ -31,6 +31,10 @@ impl InverterBoard {
 	#[cfg(feature = "inverter")]
 	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
 		let message = format!("{velocity} {throttle}\n");
+		debug!(
+			"Sending inverter control message: {} {}",
+			velocity, throttle
+		);
 		self.uart.write(message.as_bytes()).unwrap();
 	}
 
@@ -42,7 +46,7 @@ impl InverterBoard {
 	/// Combine velocity and throttle into a space-separated string message
 	#[cfg(not(feature = "inverter"))]
 	pub fn send_control(&mut self, velocity: f32, throttle: f32) {
-		info!(
+		debug!(
 			"Mocking inverter sending message: {} {}",
 			velocity, throttle
 		);

--- a/pod-operation/src/components/lidar.rs
+++ b/pod-operation/src/components/lidar.rs
@@ -18,6 +18,7 @@ impl Lidar {
 			.expect("Failed to initialize I2C device");
 		let lidar_lite = LidarLiteV3::new(i2cdev).expect("Failed to initialize LidarLiteV3");
 
+		info!("Initialized LidarLite");
 		Lidar { lidar_lite }
 	}
 

--- a/pod-operation/src/components/lidar.rs
+++ b/pod-operation/src/components/lidar.rs
@@ -1,13 +1,18 @@
-use i2cdev::linux::LinuxI2CDevice;
-use lidar_lite_v3::LidarLiteV3;
+use tracing::info;
 
+#[cfg(feature = "rpi")]
+use {i2cdev::linux::LinuxI2CDevice, lidar_lite_v3::LidarLiteV3};
+
+#[cfg(feature = "rpi")]
 const LIDAR_ADDRESS: u16 = 0x62;
 
 pub struct Lidar {
+	#[cfg(feature = "rpi")]
 	lidar_lite: LidarLiteV3<LinuxI2CDevice>,
 }
 
 impl Lidar {
+	#[cfg(feature = "rpi")]
 	pub fn new() -> Lidar {
 		let i2cdev = LinuxI2CDevice::new("/dev/i2c-1", LIDAR_ADDRESS)
 			.expect("Failed to initialize I2C device");
@@ -16,9 +21,21 @@ impl Lidar {
 		Lidar { lidar_lite }
 	}
 
+	#[cfg(not(feature = "rpi"))]
+	pub fn new() -> Lidar {
+		info!("Mocking lidar device");
+		Lidar {}
+	}
+
 	/// Convert the distance from centimeters to meters
+	#[cfg(feature = "rpi")]
 	pub fn read_distance(&mut self) -> f32 {
 		let distance = self.lidar_lite.read_distance(false).unwrap();
 		f32::from(distance) / 100.0
+	}
+
+	#[cfg(not(feature = "rpi"))]
+	pub fn read_distance(&mut self) -> f32 {
+		100.0
 	}
 }

--- a/pod-operation/src/components/lidar.rs
+++ b/pod-operation/src/components/lidar.rs
@@ -1,18 +1,18 @@
 use tracing::info;
 
-#[cfg(feature = "rpi")]
+#[cfg(feature = "lidar")]
 use {i2cdev::linux::LinuxI2CDevice, lidar_lite_v3::LidarLiteV3};
 
-#[cfg(feature = "rpi")]
+#[cfg(feature = "lidar")]
 const LIDAR_ADDRESS: u16 = 0x62;
 
 pub struct Lidar {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "lidar")]
 	lidar_lite: LidarLiteV3<LinuxI2CDevice>,
 }
 
 impl Lidar {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "lidar")]
 	pub fn new() -> Lidar {
 		let i2cdev = LinuxI2CDevice::new("/dev/i2c-1", LIDAR_ADDRESS)
 			.expect("Failed to initialize I2C device");
@@ -21,20 +21,20 @@ impl Lidar {
 		Lidar { lidar_lite }
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "lidar"))]
 	pub fn new() -> Lidar {
 		info!("Mocking lidar device");
 		Lidar {}
 	}
 
 	/// Convert the distance from centimeters to meters
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "lidar")]
 	pub fn read_distance(&mut self) -> f32 {
 		let distance = self.lidar_lite.read_distance(false).unwrap();
 		f32::from(distance) / 100.0
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "lidar"))]
 	pub fn read_distance(&mut self) -> f32 {
 		100.0
 	}

--- a/pod-operation/src/components/lim_current.rs
+++ b/pod-operation/src/components/lim_current.rs
@@ -16,9 +16,7 @@ const SENSITIVITY: f32 = 0.066; //Unit: vots/amp (v/a)
 
 fn voltage_to_current(voltage: i16) -> f32 {
 	let voltage = f32::from(voltage) / 1000.0;
-	let current = (voltage - QUIESCENT_VOLTAGE) / SENSITIVITY;
-	println!("Voltage: {}", voltage);
-	current
+	(voltage - QUIESCENT_VOLTAGE) / SENSITIVITY
 }
 
 pub struct LimCurrent {
@@ -33,12 +31,13 @@ impl LimCurrent {
 		let mut adc = Ads1x1x::new_ads1015(i2cdev, device_address);
 		adc.set_full_scale_range(FullScaleRange::Within4_096V)
 			.unwrap();
+		info!("Configured ADS1015 for for LimCurrent");
 		LimCurrent { ads1015: adc }
 	}
 
 	#[cfg(not(feature = "ads1015"))]
 	pub fn new(device_address: SlaveAddr) -> Self {
-		info!("Mocking ADS at {:?} for LimCurrnt", device_address);
+		info!("Mocking ADS at {:?} for LimCurrent", device_address);
 		LimCurrent {}
 	}
 

--- a/pod-operation/src/components/lim_current.rs
+++ b/pod-operation/src/components/lim_current.rs
@@ -1,6 +1,6 @@
 use ads1x1x::SlaveAddr;
 use tracing::info;
-#[cfg(feature = "rpi")]
+#[cfg(feature = "ads1015")]
 use {
 	ads1x1x::ic::{Ads1015, Resolution12Bit},
 	ads1x1x::interface::I2cInterface,
@@ -22,12 +22,12 @@ fn voltage_to_current(voltage: i16) -> f32 {
 }
 
 pub struct LimCurrent {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ads1015")]
 	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, OneShot>,
 }
 
 impl LimCurrent {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ads1015")]
 	pub fn new(device_address: SlaveAddr) -> Self {
 		let i2cdev = I2c::new().unwrap();
 		let mut adc = Ads1x1x::new_ads1015(i2cdev, device_address);
@@ -36,18 +36,18 @@ impl LimCurrent {
 		LimCurrent { ads1015: adc }
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "ads1015"))]
 	pub fn new(device_address: SlaveAddr) -> Self {
 		info!("Mocking ADS at {:?} for LimCurrnt", device_address);
 		LimCurrent {}
 	}
 
 	pub fn cleanup(self) {
-		#[cfg(feature = "rpi")]
+		#[cfg(feature = "ads1015")]
 		self.ads1015.destroy_ads1015();
 	}
 
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ads1015")]
 	pub fn read_currents(&mut self) -> (f32, f32, f32) {
 		[SingleA0, SingleA1, SingleA2]
 			.map(|channel| block!(self.ads1015.read(channel)).unwrap() * 2)
@@ -55,7 +55,7 @@ impl LimCurrent {
 			.into()
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "ads1015"))]
 	pub fn read_currents(&mut self) -> (f32, f32, f32) {
 		[2500, 2500, 2500].map(voltage_to_current).into()
 	}

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -67,6 +67,6 @@ impl LimTemperature {
 
 	#[cfg(not(feature = "ads1015"))]
 	pub fn read_lim_temps(&mut self) -> [f32; 4] {
-		[0.0, 0.0, 0.0, 0.0].map(voltage_to_temp)
+		[0.45, 0.45, 0.45, 0.45].map(voltage_to_temp)
 	}
 }

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -1,10 +1,16 @@
-use ads1x1x::ic::{Ads1015, Resolution12Bit};
-use ads1x1x::interface::I2cInterface;
-use ads1x1x::mode::OneShot;
-use ads1x1x::ChannelSelection::{SingleA0, SingleA1, SingleA2, SingleA3};
-use ads1x1x::{Ads1x1x, DynamicOneShot, SlaveAddr};
-use nb::block;
-use rppal::i2c::I2c;
+#[cfg(feature = "rpi")]
+use {
+	ads1x1x::ic::{Ads1015, Resolution12Bit},
+	ads1x1x::interface::I2cInterface,
+	ads1x1x::mode::OneShot,
+	ads1x1x::ChannelSelection::{SingleA0, SingleA1, SingleA2, SingleA3},
+	ads1x1x::{Ads1x1x, DynamicOneShot},
+	nb::block,
+	rppal::i2c::I2c,
+};
+
+use ads1x1x::SlaveAddr;
+use tracing::info;
 
 const C_TO_K_CONVERSION: f32 = 273.15;
 
@@ -26,23 +32,41 @@ fn voltage_to_temp(voltage: f32) -> f32 {
 }
 
 pub struct LimTemperature {
+	#[cfg(feature = "rpi")]
 	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, OneShot>,
 }
 
 impl LimTemperature {
+	#[cfg(feature = "rpi")]
 	pub fn new(device_address: SlaveAddr) -> Self {
 		let i2cdev = I2c::new().unwrap();
 		let adc = Ads1x1x::new_ads1015(i2cdev, device_address);
-		LimTemperature { ads1015: adc }
+		LimTemperature {
+			// ads1015: Mutex::new(adc),
+			ads1015: adc,
+		}
+	}
+
+	#[cfg(not(feature = "rpi"))]
+	pub fn new(device_address: SlaveAddr) -> Self {
+		info!("Mocking ADS at {:?} for LimTemperature", device_address);
+		LimTemperature {}
 	}
 
 	pub fn cleanup(self) {
+		#[cfg(feature = "rpi")]
 		self.ads1015.destroy_ads1015();
 	}
 
+	#[cfg(feature = "rpi")]
 	pub fn read_lim_temps(&mut self) -> [f32; 4] {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
 			.map(|channel| f32::from(block!(self.ads1015.read(channel)).unwrap()) / 1000.0)
 			.map(voltage_to_temp)
+	}
+
+	#[cfg(not(feature = "rpi"))]
+	pub fn read_lim_temps(&mut self) -> [f32; 4] {
+		[0.0, 0.0, 0.0, 0.0].map(voltage_to_temp)
 	}
 }

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -41,10 +41,8 @@ impl LimTemperature {
 	pub fn new(device_address: SlaveAddr) -> Self {
 		let i2cdev = I2c::new().unwrap();
 		let adc = Ads1x1x::new_ads1015(i2cdev, device_address);
-		LimTemperature {
-			// ads1015: Mutex::new(adc),
-			ads1015: adc,
-		}
+		info!("Configured ADS1015 for for LimTemperature");
+		LimTemperature { ads1015: adc }
 	}
 
 	#[cfg(not(feature = "ads1015"))]

--- a/pod-operation/src/components/lim_temperature.rs
+++ b/pod-operation/src/components/lim_temperature.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rpi")]
+#[cfg(feature = "ads1015")]
 use {
 	ads1x1x::ic::{Ads1015, Resolution12Bit},
 	ads1x1x::interface::I2cInterface,
@@ -32,12 +32,12 @@ fn voltage_to_temp(voltage: f32) -> f32 {
 }
 
 pub struct LimTemperature {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ads1015")]
 	ads1015: Ads1x1x<I2cInterface<I2c>, Ads1015, Resolution12Bit, OneShot>,
 }
 
 impl LimTemperature {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ads1015")]
 	pub fn new(device_address: SlaveAddr) -> Self {
 		let i2cdev = I2c::new().unwrap();
 		let adc = Ads1x1x::new_ads1015(i2cdev, device_address);
@@ -47,25 +47,25 @@ impl LimTemperature {
 		}
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "ads1015"))]
 	pub fn new(device_address: SlaveAddr) -> Self {
 		info!("Mocking ADS at {:?} for LimTemperature", device_address);
 		LimTemperature {}
 	}
 
 	pub fn cleanup(self) {
-		#[cfg(feature = "rpi")]
+		#[cfg(feature = "ads1015")]
 		self.ads1015.destroy_ads1015();
 	}
 
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ads1015")]
 	pub fn read_lim_temps(&mut self) -> [f32; 4] {
 		[SingleA0, SingleA1, SingleA2, SingleA3]
 			.map(|channel| f32::from(block!(self.ads1015.read(channel)).unwrap()) / 1000.0)
 			.map(voltage_to_temp)
 	}
 
-	#[cfg(not(feature = "rpi"))]
+	#[cfg(not(feature = "ads1015"))]
 	pub fn read_lim_temps(&mut self) -> [f32; 4] {
 		[0.0, 0.0, 0.0, 0.0].map(voltage_to_temp)
 	}

--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -96,7 +96,7 @@ impl PressureTransducer {
 		#[cfg(feature = "ina219")]
 		let current = self.read_current();
 		#[cfg(not(feature = "ina219"))]
-		let current = 4.0;
+		let current = 11.5; // demo value
 
 		let Reference {
 			pressure_lo,

--- a/pod-operation/src/components/pressure_transducer.rs
+++ b/pod-operation/src/components/pressure_transducer.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rpi")]
+#[cfg(feature = "ina219")]
 use rppal::i2c::I2c;
 
 use ina219::INA219;
@@ -50,7 +50,7 @@ impl Reference {
 	}
 }
 
-#[cfg(feature = "rpi")]
+#[cfg(feature = "ina219")]
 fn init_ina(device_address: u8) -> INA219<I2c> {
 	let device = I2c::new().unwrap();
 
@@ -64,7 +64,7 @@ fn init_ina(device_address: u8) -> INA219<I2c> {
 }
 
 pub struct PressureTransducer {
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ina219")]
 	ina: INA219<I2c>,
 	ref_values: Reference,
 }
@@ -74,7 +74,7 @@ impl PressureTransducer {
 	// grounded. That is, the device address is 0x40.
 	pub fn upstream() -> Self {
 		Self {
-			#[cfg(feature = "rpi")]
+			#[cfg(feature = "ina219")]
 			ina: init_ina(INA219_UPSTREAM_ADDRESS),
 			ref_values: Reference::upstream(),
 		}
@@ -84,7 +84,7 @@ impl PressureTransducer {
 	// jumped. That is, the device address is 0x41.
 	pub fn downstream() -> Self {
 		Self {
-			#[cfg(feature = "rpi")]
+			#[cfg(feature = "ina219")]
 			ina: init_ina(INA219_DOWNSTREAM_ADDRESS),
 			ref_values: Reference::downstream(),
 		}
@@ -93,9 +93,9 @@ impl PressureTransducer {
 	// Read current from the INA219 and apply a scaling factor to translate
 	// the current reading to PSI.
 	pub fn read_pressure(&mut self) -> f32 {
-		#[cfg(feature = "rpi")]
+		#[cfg(feature = "ina219")]
 		let current = self.read_current();
-		#[cfg(not(feature = "rpi"))]
+		#[cfg(not(feature = "ina219"))]
 		let current = 4.0;
 
 		let Reference {
@@ -110,7 +110,7 @@ impl PressureTransducer {
 
 	// Read from the INA219 and divide the reading by a scalar factor to
 	// convert the reading to mA.
-	#[cfg(feature = "rpi")]
+	#[cfg(feature = "ina219")]
 	fn read_current(&mut self) -> f32 {
 		f32::from(self.ina.current().unwrap()) / INA219_SCALING_VALUE
 	}

--- a/pod-operation/src/components/signal_light.rs
+++ b/pod-operation/src/components/signal_light.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "gpio"))]
-use crate::utils::mock::OutputPin;
+use crate::utils::mock::gpio::OutputPin;
 #[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, OutputPin};
 

--- a/pod-operation/src/components/signal_light.rs
+++ b/pod-operation/src/components/signal_light.rs
@@ -1,6 +1,6 @@
-#[cfg(not(feature = "rpi"))]
+#[cfg(not(feature = "gpio"))]
 use crate::utils::mock::OutputPin;
-#[cfg(feature = "rpi")]
+#[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, OutputPin};
 
 use tracing::debug;
@@ -14,11 +14,11 @@ pub struct SignalLight {
 impl SignalLight {
 	pub fn new() -> Self {
 		SignalLight {
-			#[cfg(not(feature = "rpi"))]
+			#[cfg(not(feature = "gpio"))]
 			pin: OutputPin {
 				pin: GpioPins::CONTACTOR_RELAY.into(),
 			},
-			#[cfg(feature = "rpi")]
+			#[cfg(feature = "gpio")]
 			pin: Gpio::new()
 				.unwrap()
 				.get(GpioPins::SIGNAL_LIGHT_RELAY.into())

--- a/pod-operation/src/components/signal_light.rs
+++ b/pod-operation/src/components/signal_light.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "rpi"))]
+use crate::utils::mock::OutputPin;
+#[cfg(feature = "rpi")]
 use rppal::gpio::{Gpio, OutputPin};
+
 use tracing::debug;
 
 use crate::utils::GpioPins;
@@ -10,6 +14,11 @@ pub struct SignalLight {
 impl SignalLight {
 	pub fn new() -> Self {
 		SignalLight {
+			#[cfg(not(feature = "rpi"))]
+			pin: OutputPin {
+				pin: GpioPins::CONTACTOR_RELAY.into(),
+			},
+			#[cfg(feature = "rpi")]
 			pin: Gpio::new()
 				.unwrap()
 				.get(GpioPins::SIGNAL_LIGHT_RELAY.into())

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -1,7 +1,7 @@
 use std::{ops::Sub, time::Instant};
 
 #[cfg(not(feature = "gpio"))]
-use crate::utils::mock::{InputPin, Level};
+use crate::utils::mock::gpio::{InputPin, Level};
 #[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, InputPin, Level};
 

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -1,8 +1,8 @@
 use std::{ops::Sub, time::Instant};
 
-#[cfg(not(feature = "rpi"))]
+#[cfg(not(feature = "gpio"))]
 use crate::utils::mock::{InputPin, Level};
-#[cfg(feature = "rpi")]
+#[cfg(feature = "gpio")]
 use rppal::gpio::{Gpio, InputPin, Level};
 
 use crate::utils::GpioPins;
@@ -71,24 +71,24 @@ pub struct WheelEncoder {
 
 impl WheelEncoder {
 	pub fn new() -> Self {
-		#[cfg(feature = "rpi")]
+		#[cfg(feature = "gpio")]
 		let gpio = Gpio::new().unwrap();
-		#[cfg(feature = "rpi")]
+		#[cfg(feature = "gpio")]
 		let pin_a = gpio
 			.get(GpioPins::WHEEL_ENCODER_A.into())
 			.unwrap()
 			.into_input();
-		#[cfg(feature = "rpi")]
+		#[cfg(feature = "gpio")]
 		let pin_b = gpio
 			.get(GpioPins::WHEEL_ENCODER_B.into())
 			.unwrap()
 			.into_input();
 
-		#[cfg(not(feature = "rpi"))]
+		#[cfg(not(feature = "gpio"))]
 		let pin_a = InputPin {
 			pin: GpioPins::WHEEL_ENCODER_A.into(),
 		};
-		#[cfg(not(feature = "rpi"))]
+		#[cfg(not(feature = "gpio"))]
 		let pin_b = InputPin {
 			pin: GpioPins::WHEEL_ENCODER_B.into(),
 		};

--- a/pod-operation/src/components/wheel_encoder.rs
+++ b/pod-operation/src/components/wheel_encoder.rs
@@ -1,5 +1,8 @@
 use std::{ops::Sub, time::Instant};
 
+#[cfg(not(feature = "rpi"))]
+use crate::utils::mock::{InputPin, Level};
+#[cfg(feature = "rpi")]
 use rppal::gpio::{Gpio, InputPin, Level};
 
 use crate::utils::GpioPins;
@@ -68,15 +71,27 @@ pub struct WheelEncoder {
 
 impl WheelEncoder {
 	pub fn new() -> Self {
+		#[cfg(feature = "rpi")]
 		let gpio = Gpio::new().unwrap();
+		#[cfg(feature = "rpi")]
 		let pin_a = gpio
 			.get(GpioPins::WHEEL_ENCODER_A.into())
 			.unwrap()
 			.into_input();
+		#[cfg(feature = "rpi")]
 		let pin_b = gpio
 			.get(GpioPins::WHEEL_ENCODER_B.into())
 			.unwrap()
 			.into_input();
+
+		#[cfg(not(feature = "rpi"))]
+		let pin_a = InputPin {
+			pin: GpioPins::WHEEL_ENCODER_A.into(),
+		};
+		#[cfg(not(feature = "rpi"))]
+		let pin_b = InputPin {
+			pin: GpioPins::WHEEL_ENCODER_B.into(),
+		};
 
 		let initial_state = encode_state(pin_a.read(), pin_b.read());
 

--- a/pod-operation/src/main.rs
+++ b/pod-operation/src/main.rs
@@ -24,6 +24,9 @@ use crate::state_machine::StateMachine;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	tracing::subscriber::set_global_default(FmtSubscriber::default())?;
 
+	#[cfg(not(feature = "rpi"))]
+	info!("NOTE: Did not compile for Raspberry Pi, peripherals will be mocked.");
+
 	let (layer, io) = SocketIo::new_layer();
 
 	let signal_light = SignalLight::new();

--- a/pod-operation/src/utils/mock.rs
+++ b/pod-operation/src/utils/mock.rs
@@ -1,0 +1,46 @@
+use tracing::info;
+
+/// Pin logic levels, copied from rppal::gpio
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[repr(u8)]
+pub enum Level {
+	Low = 0,
+	High = 1,
+}
+
+/// Mock for GPIO InputPin
+pub struct InputPin {
+	pub(crate) pin: u8,
+}
+
+impl InputPin {
+	pub fn read(&self) -> Level {
+		info!("Mocking reading pin {} as low", self.pin);
+		Level::Low
+	}
+
+	pub fn is_low(&self) -> bool {
+		info!("Mocking reading pin {} as low", self.pin);
+		true
+	}
+
+	pub fn is_high(&self) -> bool {
+		info!("Mocking reading pin {} as low", self.pin);
+		false
+	}
+}
+
+/// Mock for GPIO OutputPin
+pub struct OutputPin {
+	pub(crate) pin: u8,
+}
+
+impl OutputPin {
+	pub fn set_low(&self) {
+		info!("Mocking pin {} to low", self.pin);
+	}
+
+	pub fn set_high(&self) {
+		info!("Mocking pin {} to high", self.pin);
+	}
+}

--- a/pod-operation/src/utils/mock.rs
+++ b/pod-operation/src/utils/mock.rs
@@ -1,46 +1,51 @@
-use tracing::info;
+#[cfg(not(feature = "gpio"))]
+pub mod gpio {
+	use tracing::{debug, info};
 
-/// Pin logic levels, copied from rppal::gpio
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-#[repr(u8)]
-pub enum Level {
-	Low = 0,
-	High = 1,
-}
-
-/// Mock for GPIO InputPin
-pub struct InputPin {
-	pub(crate) pin: u8,
-}
-
-impl InputPin {
-	pub fn read(&self) -> Level {
-		info!("Mocking reading pin {} as low", self.pin);
-		Level::Low
+	/// Pin logic levels, copied from rppal::gpio
+	#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+	#[repr(u8)]
+	#[allow(dead_code)]
+	pub enum Level {
+		Low = 0,
+		High = 1,
 	}
 
-	pub fn is_low(&self) -> bool {
-		info!("Mocking reading pin {} as low", self.pin);
-		true
+	/// Mock for GPIO InputPin
+	pub struct InputPin {
+		pub(crate) pin: u8,
 	}
 
-	pub fn is_high(&self) -> bool {
-		info!("Mocking reading pin {} as low", self.pin);
-		false
+	#[allow(dead_code)]
+	impl InputPin {
+		pub fn read(&self) -> Level {
+			debug!("Mocking reading pin {} as low", self.pin);
+			Level::Low
+		}
+
+		pub fn is_low(&self) -> bool {
+			debug!("Mocking reading pin {} as low", self.pin);
+			true
+		}
+
+		pub fn is_high(&self) -> bool {
+			debug!("Mocking reading pin {} as low", self.pin);
+			false
+		}
 	}
-}
 
-/// Mock for GPIO OutputPin
-pub struct OutputPin {
-	pub(crate) pin: u8,
-}
-
-impl OutputPin {
-	pub fn set_low(&self) {
-		info!("Mocking pin {} to low", self.pin);
+	/// Mock for GPIO OutputPin
+	pub struct OutputPin {
+		pub(crate) pin: u8,
 	}
 
-	pub fn set_high(&self) {
-		info!("Mocking pin {} to high", self.pin);
+	impl OutputPin {
+		pub fn set_low(&self) {
+			info!("Mocking pin {} to low", self.pin);
+		}
+
+		pub fn set_high(&self) {
+			info!("Mocking pin {} to high", self.pin);
+		}
 	}
 }

--- a/pod-operation/src/utils/mod.rs
+++ b/pod-operation/src/utils/mod.rs
@@ -1,2 +1,4 @@
 mod gpio;
+pub mod mock;
+
 pub use gpio::GpioPins;


### PR DESCRIPTION
The pod program cannot be run properly unless on an actual Raspberry Pi. To simplify testing of state transitions and sending data to the control station as well as testing individual components even on the Pi, we can use feature flags to conditionally enable different component features to use. Each sensor type has a feature and the `rpi` feature will enable all of them.

Resolves #40.

## Changes
- Implemented mocking for GPIO operation
- Mock measurement values for components using other I2C-based sensors as well as inverter board using serial
  - Include reasonable placeholder values for sensor measurements
- Add `brpi` alias to do a release build with the aarch64 architecture for the Raspberry Pi
- Update checks workflow and pre-commit script to lint both with and without the `rpi` feature